### PR TITLE
update sca schema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,7 @@ async function compareScaResults(oldReport: string, newReport: string) {
     info("There was changes in the following SCA issues:")
     for (const vuln of results.Vulnerabilities) {
       info(JSON.stringify(vuln, null, 2))
-      if (vuln.hasOwnProperty('Compare') && vuln.Compare.hasOwnProperty('Status') && vuln.Compare.Status === "added") {
+      if (vuln.Compare?.Status === "added") {
         alertsAdded.push(`[${vuln.Info.ExternalId}](${vuln.Info.Link}): ${vuln.Info.Description}`)
       }
     }


### PR DESCRIPTION
Following the change of the schema in this [commit](https://github.com/lacework-dev/meta-scanner/commit/1b9ca529e7aab667734a57b1d92bf781ef663a2f#diff-e91d654a3ab94448b42e10bda648c0382bdf0ec877eef814968347802d56010eR154) 

Note that now `Compare` and `Compare.Status` can be missing if we run `sca compare` with flag `--unchanged`.

An example of new output:
```
	"Vulnerabilities": [
		{
			"Id": "",
			"AffectedArtifactIds": [
				"6682b08d-ea45-4c03-b85f-f2f41823efb0"
			],
			"Info": {
				"ExternalId": "CVE-2021-42550",
				"Description": "In logback version 1.2.9 and prior versions, an attacker with the required privileges to edit configurations files could craft a malicious configuration allowing to execute arbitrary code loaded from LDAP servers.",
				"Status": "vulnerable",
				"Severity": "medium",
				"Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42550",
				"FixVersion": {
					"Type": "maven",
					"Version": "1.2.9"
				},
				"CVSSv2": {
					"PublishedDateTime": "2021-12-16T19:15:00Z",
					"Score": 8.5,
					"Vectors": "AV:N/AC:M/Au:S/C:C/I:C/A:C"
				},
				"CVSSv3": {
					"ExploitabilityScore": 0.7,
					"ImpactScore": 5.9,
					"Score": 6.6,
					"Vectors": "CVSS:3.0/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H"
				}
			},
			"Compare": {
				"Hash": "acca534ddaf0e3b4f0f3dd7180ef981300f6f460",
				"Status": "removed"
			}
		}
```