### PR TITLE
disable source control referencing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ async function main() {
     const tools = (getInput('tools') || "sca").toLowerCase().split(",")
     const toUpload: string[] = []
     if (tools.includes("sca")) {
-      info(await callLaceworkCli("sca", "dir", ".", "-o", scaReport, "--no-scr"))
+      info(await callLaceworkCli("sca", "dir", ".", "--no-scr", "-o", scaReport))
       await printScaResults(scaReport)
       toUpload.push(scaReport)
     }


### PR DESCRIPTION
We do not use source control referencing at the moment. Disabling it will improve performances significantly.