### PR TITLE
Improve local development experience

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,22 +1,19 @@
 {
-    "env": {
-        "commonjs": true,
-        "es2021": true,
-        "node": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended"
-    ],
-    "overrides": [
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": "latest"
-    },
-    "plugins": [
-        "@typescript-eslint"
-    ],
-    "rules": {
-    }
+  "env": {
+    "commonjs": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": ["prettier"],
+  "overrides": [],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "project": ["./tsconfig.json"]
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-underscore-dangle": "error"
+  }
 }

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,9 +2,9 @@ name: Unit tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
@@ -16,4 +16,6 @@ jobs:
         with:
           node-version: 16
       - run: npm ci
+      - run: npm run lint-check
+      - run: npm run pretty-check
       - run: npm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint-fix && npm run pretty-fix

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint-check && npm run pretty-check && npm run test

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true,
+  "printWidth": 100
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint", "orta.vscode-jest"]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "configurations": [
+    {
+      "type": "node",
+      "name": "Tests",
+      "request": "launch",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "cwd": "${workspaceFolder}/test",
+      "runtimeExecutable": "npm",
+      "args": ["run", "test", "--", "--runInBand", "--watchAll=false"]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,26 @@
 {
-    "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
-    },
-    "eslint.validate": [
-        "typescript"
-    ],
-    "files.insertFinalNewline": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "eslint.validate": ["typescript"],
+  "files.insertFinalNewline": true,
+  "editor.formatOnSave": true,
+  "prettier.enable": true,
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "jest.jestCommandLine": "npm run test --",
+  "jest.autoRun": "false"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt-get install -y nodejs
 RUN npm install -g npm@latest
 RUN npm install
-RUN npx tsc
+RUN npm run compile
 RUN curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,3 +1,3 @@
 {
-    "preset": "ts-jest"
+  "preset": "ts-jest"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,16 @@
       "dependencies": {
         "@actions/artifact": "^1.1.0",
         "@actions/core": "^1.10.0",
-        "@actions/github": "^5.1.1"
+        "@actions/github": "^5.1.1",
+        "eslint-config-prettier": "^8.5.0",
+        "prettier": "^2.8.1"
       },
       "devDependencies": {
         "@types/jest": "^29.2.4",
         "@typescript-eslint/eslint-plugin": "^5.46.1",
         "@typescript-eslint/parser": "^5.46.1",
         "eslint": "^8.29.0",
+        "husky": "^8.0.0",
         "ts-jest": "^29.0.3",
         "typescript": "^4.9.4"
       }
@@ -685,7 +688,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
       "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
-      "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -707,14 +709,12 @@
     "node_modules/@eslint/eslintrc/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.19.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
       "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
-      "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -729,7 +729,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -741,7 +740,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -753,7 +751,6 @@
       "version": "0.11.7",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
       "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
-      "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -767,7 +764,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -779,8 +775,7 @@
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-      "dev": true
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1154,7 +1149,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -1167,7 +1161,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -1176,7 +1169,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -1683,7 +1675,6 @@
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
       "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1695,7 +1686,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -1704,7 +1694,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1736,7 +1725,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1745,7 +1733,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1978,7 +1965,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2014,7 +2000,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2089,7 +2074,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2100,8 +2084,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2119,7 +2102,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2133,7 +2115,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2156,8 +2137,7 @@
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "node_modules/deepmerge": {
       "version": "4.2.2",
@@ -2209,7 +2189,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -2277,7 +2256,6 @@
       "version": "8.29.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
       "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
-      "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.3",
         "@humanwhocodes/config-array": "^0.11.6",
@@ -2329,6 +2307,17 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -2346,7 +2335,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
       "dependencies": {
         "eslint-visitor-keys": "^2.0.0"
       },
@@ -2364,7 +2352,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -2373,7 +2360,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -2381,14 +2367,12 @@
     "node_modules/eslint/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -2400,7 +2384,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
       "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-      "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -2413,7 +2396,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -2422,7 +2404,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -2438,7 +2419,6 @@
       "version": "13.19.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
       "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
-      "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -2453,7 +2433,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -2465,7 +2444,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -2480,7 +2458,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -2495,7 +2472,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -2507,7 +2483,6 @@
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
       "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
-      "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -2538,7 +2513,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
       "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-      "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -2550,7 +2524,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -2559,7 +2532,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -2571,7 +2543,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -2589,7 +2560,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2647,8 +2617,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -2681,20 +2650,17 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fastq": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
       "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
-      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -2713,7 +2679,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "dev": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -2751,7 +2716,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-      "dev": true,
       "dependencies": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
@@ -2763,8 +2727,7 @@
     "node_modules/flatted": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-      "dev": true
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2859,7 +2822,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -2906,8 +2868,7 @@
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "dev": true
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -2926,7 +2887,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2948,11 +2908,25 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/husky": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
+      "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
       "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -2961,7 +2935,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -2977,7 +2950,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -3006,7 +2978,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -3049,7 +3020,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3078,7 +3048,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -3099,7 +3068,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3128,8 +3096,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -3803,7 +3770,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
       "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
@@ -3852,14 +3818,12 @@
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
     "node_modules/json5": {
       "version": "2.2.1",
@@ -3897,7 +3861,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -3935,8 +3898,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -4035,14 +3997,12 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
     "node_modules/natural-compare-lite": {
       "version": "1.4.0",
@@ -4134,7 +4094,6 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
       "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-      "dev": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -4151,7 +4110,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -4205,7 +4163,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -4236,7 +4193,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4253,7 +4209,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4320,9 +4275,22 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -4369,7 +4337,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4378,7 +4345,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4404,7 +4370,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -4477,7 +4442,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -4501,7 +4465,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4534,7 +4497,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -4546,7 +4508,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4647,7 +4608,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4679,7 +4639,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -4691,7 +4650,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4730,8 +4688,7 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
     "node_modules/tmp": {
       "version": "0.2.1",
@@ -4877,7 +4834,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -4957,7 +4913,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -5020,7 +4975,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5035,7 +4989,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5125,7 +5078,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -6,10 +6,18 @@
   "dependencies": {
     "@actions/artifact": "^1.1.0",
     "@actions/core": "^1.10.0",
-    "@actions/github": "^5.1.1"
+    "@actions/github": "^5.1.1",
+    "eslint-config-prettier": "^8.5.0",
+    "prettier": "^2.8.1"
   },
   "scripts": {
-    "test": "jest"
+    "test": "npx jest",
+    "compile": "npx tsc",
+    "lint-check": "npx eslint **/*.ts",
+    "lint-fix": "npx eslint --fix **/*.ts",
+    "pretty-check": "npx prettier --check **/*.ts **/*.yml **/*.json",
+    "pretty-fix": "npx prettier --write **/*.ts **/*.yml **/*.json",
+    "prepare": "npx husky install"
   },
   "repository": {
     "type": "git",
@@ -27,6 +35,7 @@
     "@typescript-eslint/eslint-plugin": "^5.46.1",
     "@typescript-eslint/parser": "^5.46.1",
     "eslint": "^8.29.0",
+    "husky": "^8.0.0",
     "ts-jest": "^29.0.3",
     "typescript": "^4.9.4"
   }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,0 +1,27 @@
+import { create } from '@actions/artifact'
+import { startGroup, endGroup, getInput } from '@actions/core'
+import { context, getOctokit } from '@actions/github'
+
+export async function uploadArtifact(artifactName: string, ...files: string[]) {
+  startGroup('Uploading artifact ' + artifactName)
+  await create().uploadArtifact(artifactName, files, '.')
+  endGroup()
+}
+
+export async function downloadArtifact(artifactName: string) {
+  startGroup('Downloading artifact ' + artifactName)
+  await create().downloadArtifact(artifactName, '.', {
+    createArtifactFolder: true,
+  })
+  endGroup()
+}
+
+export async function postCommentIfInPr(message: string) {
+  if (context.payload.pull_request) {
+    await getOctokit(getInput('token')).rest.issues.createComment({
+      ...context.repo,
+      issue_number: context.payload.pull_request.number,
+      body: message,
+    })
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,193 +1,85 @@
-import { error, info, startGroup, endGroup, getInput, setOutput, isDebug } from '@actions/core';
-import { create } from '@actions/artifact';
-import { context, getOctokit } from '@actions/github';
-import { spawnSync } from 'child_process';
-import { readFileSync, existsSync } from 'fs';
+import { error, getInput, info, setOutput } from '@actions/core'
+import { existsSync } from 'fs'
+import { downloadArtifact, postCommentIfInPr, uploadArtifact } from './actions'
+import { compareSastResults, printSastResults } from './sast'
+import { compareScaResults, printScaResults } from './sca'
+import { callLaceworkCli } from './util'
 
-function getBooleanInput(name: string) {
-  return getInput(name).toLowerCase() === "true"
-}
+const scaReport = 'sca.json'
+const sastReport = 'sast.json'
 
-function debug() {
-  return getBooleanInput("debug") || isDebug()
-}
-
-async function callCommand(command: string, ...args: string[]) {
-  const child = spawnSync(command, args)
-  if (debug() && child.stderr.toString() !== "") {
-    info(`stderr from command:\n${child.stderr.toString()}`)
+async function runAnalysis() {
+  const target = getInput('target')
+  info('Analyzing ' + target)
+  const tools = (getInput('tools') || 'sca').toLowerCase().split(',')
+  const toUpload: string[] = []
+  if (tools.includes('sca')) {
+    info(await callLaceworkCli('sca', 'dir', '.', '--no-scr', '-o', scaReport))
+    await printScaResults(scaReport)
+    toUpload.push(scaReport)
   }
-  if (child.status) {
-    error(`Failed with status ${child.status}`)
-    process.exit(0) // TODO: Exit with 1 once we want failures to be fatal
+  if (tools.includes('sast')) {
+    info(
+      await callLaceworkCli(
+        'sast',
+        'scan',
+        '--verbose',
+        '--classes',
+        getInput('jar'),
+        '-o',
+        sastReport
+      )
+    )
+    await printSastResults(sastReport)
+    toUpload.push(sastReport)
   }
-  return child.stdout.toString().trim()
+  await uploadArtifact('results-' + target, ...toUpload)
+  setOutput(`${target}-completed`, true)
 }
 
-function getRequiredEnvVariable(name: string) {
-  const value = process.env[name]
-  if (!value) {
-    error(`Missing required environment variable ${name}`)
-    process.exit(0) // TODO: Exit with 1 once we want failures to be fatal
+async function displayResults() {
+  info('Displaying results')
+  await downloadArtifact('results-old')
+  await downloadArtifact('results-new')
+  const issuesByTool: { [tool: string]: string[] } = {}
+  if (existsSync(`results-old/${scaReport}`) && existsSync(`results-new/${scaReport}`)) {
+    issuesByTool['sca'] = await compareScaResults(
+      `results-old/${scaReport}`,
+      `results-new/${scaReport}`
+    )
   }
-  return value
-}
-
-async function callLaceworkCli(...args: string[]) {
-  const accountName = getRequiredEnvVariable("LW_ACCOUNT_NAME");
-  const apiKey = getRequiredEnvVariable("LW_API_KEY");
-  const apiSecret = getRequiredEnvVariable("LW_API_SECRET");
-  const expandedArgs = ["--noninteractive", "--account", accountName, "--api_key", apiKey, "--api_secret", apiSecret, ...args]
-  info("Calling lacework " + expandedArgs.join(" "))
-  return await callCommand("lacework", ...expandedArgs);
-}
-
-async function uploadArtifact(artifactName: string, ...files: string[]) {
-  startGroup("Uploading artifact " + artifactName)
-  await create().uploadArtifact(artifactName, files, ".")
-  endGroup()
-}
-
-async function downloadArtifact(artifactName: string) {
-  startGroup("Downloading artifact " + artifactName)
-  await create().downloadArtifact(artifactName, ".", { createArtifactFolder: true })
-  endGroup()
-}
-
-async function printScaResults(jsonFile: string) {
-  startGroup("Results for SCA")
-  const results = JSON.parse(readFileSync(jsonFile, "utf8"))
-  if (Array.isArray(results.Vulnerabilities)) {
-    info("The following SCA issues were found:")
-    for (const vuln of results.Vulnerabilities) {
-      info(JSON.stringify(vuln, null, 2))
-    }
-  } else {
-    info("No SCA issues were found")
+  if (existsSync(`results-old/${sastReport}`) && existsSync(`results-new/${sastReport}`)) {
+    issuesByTool['sast'] = await compareSastResults(
+      `results-old/${sastReport}`,
+      `results-new/${sastReport}`
+    )
   }
-  endGroup()
-}
-
-async function printSastResults(jsonFile: string) {
-  startGroup("Results for SAST")
-  const results = JSON.parse(readFileSync(jsonFile, "utf8"))
-  if (results.length > 0) {
-    info("The following SAST issues were found:")
-    for (const vuln of results) {
-      info(JSON.stringify(vuln, null, 2))
-    }
-  } else {
-    info("No SAST issues were found")
-  }
-  endGroup()
-}
-
-async function compareSastResults(oldReport: string, newReport: string) {
-  startGroup("Comparing SAST results")
-  info(await callLaceworkCli("sast", "compare", "--old", oldReport, "--new", newReport, "-o", "sast-compare.json"))
-  const results = JSON.parse(readFileSync("sast-compare.json", "utf8"))
-  const alertsAdded: string[] = []
-  if (Array.isArray(results) && results.length > 0) {
-    info("There was changes in the following SAST issues:")
-    for (const vuln of results) {
-      info(JSON.stringify(vuln, null, 2))
-      if (vuln.status === "added") {
-        const fileName = `${vuln.file.split("/").pop()}:${vuln.line}`
-        const fileUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/${context.sha}/${vuln.file}#L${vuln.line}`
-        alertsAdded.push(`[${fileName}](${fileUrl}): ${vuln.qualifier}`)
+  if (Object.values(issuesByTool).some((x) => x.length > 0) && getInput('token').length > 0) {
+    info('Posting comment to GitHub PR as there were new issues introduced:')
+    let message = `Lacework Code Analysis found potential new issues in this PR.`
+    for (const [tool, issues] of Object.entries(issuesByTool)) {
+      if (issues.length > 0) {
+        message += `\n\n<details><summary>${tool} found ${issues.length} potential new issues</summary>\n\n`
+        for (const issue in issues) {
+          message += `* ${issues[issue]}\n`
+        }
+        message += '\n</details>'
       }
     }
-    if (alertsAdded.length > 0) {
-      // TODO: Use setFailed once we want new alerts to cause a failure
-      error(`${alertsAdded.length} new SAST issues were introduced, see above in the logs for details`)
-    }
-  } else {
-    info("No changes in SAST issues")
+    info(message)
+    await postCommentIfInPr(message)
   }
-  endGroup()
-  return alertsAdded
-}
-
-async function compareScaResults(oldReport: string, newReport: string) {
-  startGroup("Comparing SCA results")
-  info(await callLaceworkCli("sca", "compare", "--old", oldReport, "--new", newReport, "-o", "sca-compare.json"))
-  const results = JSON.parse(readFileSync("sca-compare.json", "utf8"))
-  const alertsAdded: string[] = []
-  if (Array.isArray(results.Vulnerabilities) && results.Vulnerabilities.length > 0) {
-    info("There was changes in the following SCA issues:")
-    for (const vuln of results.Vulnerabilities) {
-      info(JSON.stringify(vuln, null, 2))
-      if (vuln.Compare?.Status === "added") {
-        alertsAdded.push(`[${vuln.Info.ExternalId}](${vuln.Info.Link}): ${vuln.Info.Description}`)
-      }
-    }
-    if (alertsAdded.length > 0) {
-      // TODO: Use setFailed once we want new alerts to cause a failure
-      error(`${alertsAdded.length} new SCA issues were introduced, see above in the logs for details`)
-    }
-  } else {
-    info("No changes in SCA issues")
-  }
-  endGroup()
-  return alertsAdded
+  setOutput(`display-completed`, true)
 }
 
 async function main() {
-  const target = getInput('target')
-  const scaReport = "sca.json"
-  const sastReport = "sast.json"
-  if (target !== "") {
-    info("Analyzing " + target)
-    const tools = (getInput('tools') || "sca").toLowerCase().split(",")
-    const toUpload: string[] = []
-    if (tools.includes("sca")) {
-      info(await callLaceworkCli("sca", "dir", ".", "--no-scr", "-o", scaReport))
-      await printScaResults(scaReport)
-      toUpload.push(scaReport)
-    }
-    if (tools.includes("sast")) {
-      info(await callLaceworkCli("sast", "scan", "--verbose", "--classes", getInput('jar'), "-o", sastReport))
-      await printSastResults(sastReport)
-      toUpload.push(sastReport)
-    }
-    await uploadArtifact("results-" + target, ...toUpload)
-    setOutput(`${target}-completed`, true)
+  if (getInput('target') !== '') {
+    await runAnalysis()
   } else {
-    info("Displaying results")
-    await downloadArtifact("results-old")
-    await downloadArtifact("results-new")
-    const issuesByTool: { [tool: string]: string[] } = {}
-    if (existsSync(`results-old/${scaReport}`) && existsSync(`results-new/${scaReport}`)) {
-      issuesByTool["sca"] = await compareScaResults(`results-old/${scaReport}`, `results-new/${scaReport}`)
-    }
-    if (existsSync(`results-old/${sastReport}`) && existsSync(`results-new/${sastReport}`)) {
-      issuesByTool["sast"] = await compareSastResults(`results-old/${sastReport}`, `results-new/${sastReport}`)
-    }
-    if (Object.values(issuesByTool).some(x => x.length > 0) && getInput('token').length > 0) {
-      info("Posting comment to GitHub PR as there were new issues introduced:")
-      let message = `Lacework Code Analysis found potential new issues in this PR.`;
-      for (const [tool, issues] of Object.entries(issuesByTool)) {
-        if (issues.length > 0) {
-          message += `\n\n<details><summary>${tool} found ${issues.length} potential new issues</summary>\n\n`
-          for (const issue in issues) {
-            message += `* ${issues[issue]}\n`
-          }
-          message += "\n</details>"
-        }
-      }
-      info(message)
-      if (context.payload.pull_request) {
-        await getOctokit(getInput('token')).rest.issues.createComment({
-            ...context.repo,
-            issue_number: context.payload.pull_request.number,
-            body: message
-          });
-      }
-    }
-    setOutput(`display-completed`, true)
+    await displayResults()
   }
 }
 
 main().catch(
-  err => error(err.message) // TODO: Use setFailed once we want failures to be fatal
-);
+  (err) => error(err.message) // TODO: Use setFailed once we want failures to be fatal
+)

--- a/src/sast.ts
+++ b/src/sast.ts
@@ -1,0 +1,57 @@
+import { error, info, startGroup, endGroup } from '@actions/core'
+import { context } from '@actions/github'
+import { readFileSync } from 'fs'
+import { callLaceworkCli } from './util'
+
+export async function printSastResults(jsonFile: string) {
+  startGroup('Results for SAST')
+  const results = JSON.parse(readFileSync(jsonFile, 'utf8'))
+  if (results.length > 0) {
+    info('The following SAST issues were found:')
+    for (const vuln of results) {
+      info(JSON.stringify(vuln, null, 2))
+    }
+  } else {
+    info('No SAST issues were found')
+  }
+  endGroup()
+}
+
+export async function compareSastResults(oldReport: string, newReport: string) {
+  startGroup('Comparing SAST results')
+  info(
+    await callLaceworkCli(
+      'sast',
+      'compare',
+      '--old',
+      oldReport,
+      '--new',
+      newReport,
+      '-o',
+      'sast-compare.json'
+    )
+  )
+  const results = JSON.parse(readFileSync('sast-compare.json', 'utf8'))
+  const alertsAdded: string[] = []
+  if (Array.isArray(results) && results.length > 0) {
+    info('There was changes in the following SAST issues:')
+    for (const vuln of results) {
+      info(JSON.stringify(vuln, null, 2))
+      if (vuln.status === 'added') {
+        const fileName = `${vuln.file.split('/').pop()}:${vuln.line}`
+        const fileUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/${context.sha}/${vuln.file}#L${vuln.line}`
+        alertsAdded.push(`[${fileName}](${fileUrl}): ${vuln.qualifier}`)
+      }
+    }
+    if (alertsAdded.length > 0) {
+      // TODO: Use setFailed once we want new alerts to cause a failure
+      error(
+        `${alertsAdded.length} new SAST issues were introduced, see above in the logs for details`
+      )
+    }
+  } else {
+    info('No changes in SAST issues')
+  }
+  endGroup()
+  return alertsAdded
+}

--- a/src/sca.ts
+++ b/src/sca.ts
@@ -1,0 +1,54 @@
+import { error, info, startGroup, endGroup } from '@actions/core'
+import { readFileSync } from 'fs'
+import { callLaceworkCli } from './util'
+
+export async function printScaResults(jsonFile: string) {
+  startGroup('Results for SCA')
+  const results = JSON.parse(readFileSync(jsonFile, 'utf8'))
+  if (Array.isArray(results.Vulnerabilities)) {
+    info('The following SCA issues were found:')
+    for (const vuln of results.Vulnerabilities) {
+      info(JSON.stringify(vuln, null, 2))
+    }
+  } else {
+    info('No SCA issues were found')
+  }
+  endGroup()
+}
+
+export async function compareScaResults(oldReport: string, newReport: string) {
+  startGroup('Comparing SCA results')
+  info(
+    await callLaceworkCli(
+      'sca',
+      'compare',
+      '--old',
+      oldReport,
+      '--new',
+      newReport,
+      '-o',
+      'sca-compare.json'
+    )
+  )
+  const results = JSON.parse(readFileSync('sca-compare.json', 'utf8'))
+  const alertsAdded: string[] = []
+  if (Array.isArray(results.Vulnerabilities) && results.Vulnerabilities.length > 0) {
+    info('There was changes in the following SCA issues:')
+    for (const vuln of results.Vulnerabilities) {
+      info(JSON.stringify(vuln, null, 2))
+      if (vuln.Compare?.Status === 'added') {
+        alertsAdded.push(`[${vuln.Info.ExternalId}](${vuln.Info.Link}): ${vuln.Info.Description}`)
+      }
+    }
+    if (alertsAdded.length > 0) {
+      // TODO: Use setFailed once we want new alerts to cause a failure
+      error(
+        `${alertsAdded.length} new SCA issues were introduced, see above in the logs for details`
+      )
+    }
+  } else {
+    info('No changes in SCA issues')
+  }
+  endGroup()
+  return alertsAdded
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,50 @@
+import { getInput, isDebug } from '@actions/core'
+import { error, info } from '@actions/core'
+import { spawnSync } from 'child_process'
+
+function getBooleanInput(name: string) {
+  return getInput(name).toLowerCase() === 'true'
+}
+
+export function debug() {
+  return getBooleanInput('debug') || isDebug()
+}
+
+export async function callCommand(command: string, ...args: string[]) {
+  const child = spawnSync(command, args)
+  if (debug() && child.stderr.toString() !== '') {
+    info(`stderr from command:\n${child.stderr.toString()}`)
+  }
+  if (child.status) {
+    error(`Failed with status ${child.status}`)
+    process.exit(0) // TODO: Exit with 1 once we want failures to be fatal
+  }
+  return child.stdout.toString().trim()
+}
+
+export function getRequiredEnvVariable(name: string) {
+  const value = process.env[name]
+  if (!value) {
+    error(`Missing required environment variable ${name}`)
+    process.exit(0) // TODO: Exit with 1 once we want failures to be fatal
+  }
+  return value
+}
+
+export async function callLaceworkCli(...args: string[]) {
+  const accountName = getRequiredEnvVariable('LW_ACCOUNT_NAME')
+  const apiKey = getRequiredEnvVariable('LW_API_KEY')
+  const apiSecret = getRequiredEnvVariable('LW_API_SECRET')
+  const expandedArgs = [
+    '--noninteractive',
+    '--account',
+    accountName,
+    '--api_key',
+    apiKey,
+    '--api_secret',
+    apiSecret,
+    ...args,
+  ]
+  info('Calling lacework ' + expandedArgs.join(' '))
+  return await callCommand('lacework', ...expandedArgs)
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,3 +1,0 @@
-test('placeholder', () => {
-    // No tests yet
-});

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,0 +1,21 @@
+import { debug } from '../src/util'
+
+const actionsCore = require('@actions/core')
+jest.mock('@actions/core')
+
+test('debug on via isDebug', () => {
+  actionsCore.isDebug.mockReturnValue(true)
+  actionsCore.getInput.mockReturnValue('')
+  expect(debug()).toBe(true)
+})
+
+test('debug on via debug input', () => {
+  actionsCore.getInput.mockImplementation((name: string) => (name === 'debug' ? 'true' : 'false'))
+  expect(debug()).toBe(true)
+})
+
+test('debug off by default', () => {
+  actionsCore.isDebug.mockReturnValue(false)
+  actionsCore.getInput.mockReturnValue('')
+  expect(debug()).toBe(false)
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,5 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "outDir": "dist"
-  },
-  "include": [
-    "./src/"
-  ]
+  }
 }


### PR DESCRIPTION
This PR bundles together some local development experience improvements for this repo, including:

- Splitting code out so it doesn't all live in `index.ts`.
- A few initial unit tests (more to follow: and also end-to-end tests in CI).
- Running of unit tests from VS Code.
- Linting/autoformatting rules that run both in VS Code and on commit hooks.

Perhaps some of this is overkill - we can always undo parts later if we find they're getting in the way.