### PR TITLE
Pin versions of SAST and SCA installed

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 echo "::group::Installing Lacework CLI components"
-lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sca
-lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sast
+lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sca --version 0.0.6
+lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sast --version 0.0.19
 echo "::endgroup::"
 echo "::group::Printing Lacework CLI information"
 lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" version


### PR DESCRIPTION
This will let us make breaking changes to the output formats of these without having to worry about backwards compatibility with this integration.