### PR TITLE
Bump SAST and SCA versions we run in our action

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -55,7 +55,7 @@ jobs:
             echo "::error Expected to have some SCA results!"
             exit 1
           fi
-          export SAST_RESULTS=`jq '.Vulnerabilities | length' sca.json`
+          export SAST_RESULTS=`jq '.runs[0].results | length' sast.sarif`
           echo "Got $SAST_RESULTS from SAST"
           if [ "$SAST_RESULTS" == "0" ]; then
             echo "::error Expected to have some SAST results!"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 echo "::group::Installing Lacework CLI components"
-lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sca --version 0.0.6
-lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sast --version 0.0.19
+lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sca --version 0.0.8
+lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sast --version 0.0.21
 echo "::endgroup::"
 echo "::group::Printing Lacework CLI information"
 lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" version

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@actions/artifact": "^1.1.0",
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",
+        "@types/sarif": "^2.1.4",
         "prettier": "^2.8.1"
       },
       "devDependencies": {
@@ -1422,6 +1423,11 @@
       "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@types/sarif": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.4.tgz",
+      "integrity": "sha512-4xKHMdg3foh3Va1fxTzY1qt8QVqmaJpGWsVvtjQrJBn+/bkig2pWFKJ4FPI2yLI4PAj0SUKiPO4Vd7ggYIMZjQ=="
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -3892,9 +3898,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@actions/artifact": "^1.1.0",
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",
+    "@types/sarif": "^2.1.4",
     "prettier": "^2.8.1"
   },
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { compareScaResults, printScaResults } from './sca'
 import { callLaceworkCli } from './util'
 
 const scaReport = 'sca.json'
-const sastReport = 'sast.json'
+const sastReport = 'sast.sarif'
 
 async function runAnalysis() {
   const target = getInput('target')

--- a/src/sast.ts
+++ b/src/sast.ts
@@ -2,16 +2,22 @@ import { error, info, startGroup, endGroup } from '@actions/core'
 import { context } from '@actions/github'
 import { readFileSync } from 'fs'
 import { callLaceworkCli } from './util'
+import { Log } from 'sarif'
 
-export async function printSastResults(jsonFile: string) {
+export async function printSastResults(sarifFile: string) {
   startGroup('Results for SAST')
-  const results = JSON.parse(readFileSync(jsonFile, 'utf8'))
-  if (results.length > 0) {
-    info('The following SAST issues were found:')
-    for (const vuln of results) {
-      info(JSON.stringify(vuln, null, 2))
+  let foundSomething = false
+  const results: Log = JSON.parse(readFileSync(sarifFile, 'utf8'))
+  for (const run of results.runs) {
+    if (Array.isArray(run.results) && run.results.length > 0) {
+      foundSomething = true
+      info('Found ' + run.results?.length + ' results using ' + run.tool.driver.name)
+      for (const vuln of run.results) {
+        info(JSON.stringify(vuln, null, 2))
+      }
     }
-  } else {
+  }
+  if (!foundSomething) {
     info('No SAST issues were found')
   }
   endGroup()
@@ -28,28 +34,41 @@ export async function compareSastResults(oldReport: string, newReport: string) {
       '--new',
       newReport,
       '-o',
-      'sast-compare.json'
+      'sast-compare.sarif'
     )
   )
-  const results = JSON.parse(readFileSync('sast-compare.json', 'utf8'))
+  const results: Log = JSON.parse(readFileSync('sast-compare.sarif', 'utf8'))
+  let sawChange = false
   const alertsAdded: string[] = []
-  if (Array.isArray(results) && results.length > 0) {
-    info('There was changes in the following SAST issues:')
-    for (const vuln of results) {
-      info(JSON.stringify(vuln, null, 2))
-      if (vuln.status === 'added') {
-        const fileName = `${vuln.file.split('/').pop()}:${vuln.line}`
-        const fileUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/${context.sha}/${vuln.file}#L${vuln.line}`
-        alertsAdded.push(`[${fileName}](${fileUrl}): ${vuln.qualifier}`)
+  for (const run of results.runs) {
+    if (Array.isArray(run.results) && run.results.length > 0) {
+      info('There was changes in ' + run.results.length + ' results from ' + run.tool.driver.name)
+      for (const vuln of run.results) {
+        info(JSON.stringify(vuln, null, 2))
+        if (vuln.properties?.['status'] === 'added') {
+          let location = 'Unknown location'
+          const uri = vuln.locations?.[0].physicalLocation?.artifactLocation?.uri
+          const line = vuln.locations?.[0].physicalLocation?.region?.startLine
+          if (uri !== undefined && line !== undefined) {
+            const file = uri.replace(/^file:\/*/, '')
+            const text = `${file.split('/').pop()}:${line}`
+            const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/${context.sha}/${file}#L${line}`
+            location = `[${text}](${url})`
+          }
+          const message =
+            vuln.message.markdown || vuln.message.text || 'No information available on alert'
+          alertsAdded.push(`${location}: ${message}`)
+        }
+      }
+      if (alertsAdded.length > 0) {
+        // TODO: Use setFailed once we want new alerts to cause a failure
+        error(
+          `${alertsAdded.length} new SAST issues were introduced, see above in the logs for details`
+        )
       }
     }
-    if (alertsAdded.length > 0) {
-      // TODO: Use setFailed once we want new alerts to cause a failure
-      error(
-        `${alertsAdded.length} new SAST issues were introduced, see above in the logs for details`
-      )
-    }
-  } else {
+  }
+  if (!sawChange) {
     info('No changes in SAST issues')
   }
   endGroup()


### PR DESCRIPTION
For SCA, this is trivial as no significant changes to its input flags and/or output has been made.

For SAST, it's a little trickier because we've changed the output format to SARIF. I've rewritten the parts of the action that read the output to handle this SARIF output. That means this code should now be ready to start seeing results from Pysa too.