### PR TITLE
Add output for the comment that we posted

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,19 @@ jobs:
       - run-analysis
     steps:
       - name: Results
+        id: code-analysis
         uses: lacework-dev/code-analysis-action@v0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Notify Code Security team
+        if: ${{ steps.code-analysis.outputs.posted-comment }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: code-security-notify
+          SLACK_MESSAGE: "Posted an alert on a pull request: ${{ steps.code-analysis.outputs.posted-comment }}"
+          MSG_MINIMAL: true
+          SLACK_MSG_AUTHOR: Lacework
 ```
 
 ### On push

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,5 +1,5 @@
 import { create } from '@actions/artifact'
-import { startGroup, endGroup, getInput } from '@actions/core'
+import { startGroup, endGroup, getInput, info } from '@actions/core'
 import { context, getOctokit } from '@actions/github'
 
 export async function uploadArtifact(artifactName: string, ...files: string[]) {
@@ -16,12 +16,16 @@ export async function downloadArtifact(artifactName: string) {
   endGroup()
 }
 
-export async function postCommentIfInPr(message: string) {
+export async function postCommentIfInPr(message: string): Promise<string | undefined> {
   if (context.payload.pull_request) {
-    await getOctokit(getInput('token')).rest.issues.createComment({
-      ...context.repo,
-      issue_number: context.payload.pull_request.number,
-      body: message,
-    })
+    const commentUrl = (
+      await getOctokit(getInput('token')).rest.issues.createComment({
+        ...context.repo,
+        issue_number: context.payload.pull_request.number,
+        body: message,
+      })
+    ).data.html_url
+    return commentUrl
   }
+  return undefined
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,10 @@ async function displayResults() {
       }
     }
     info(message)
-    await postCommentIfInPr(message)
+    const commentUrl = await postCommentIfInPr(message)
+    if (commentUrl !== undefined) {
+      setOutput('posted-comment', commentUrl)
+    }
   }
   setOutput(`display-completed`, true)
 }


### PR DESCRIPTION
End-to-end test was done [here](https://github.com/lacework-dev/code-analysis-test-repo/pull/4#issuecomment-1387451014), which triggered a notification as expected [here](https://lacework.slack.com/archives/C04KG90QU2F/p1674062897560659). The documentation with the recommended workflow has been updated to include the step that notifies us.