### PR TITLE
fix: Add some escaping to PR comments

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -18,11 +18,18 @@ export async function downloadArtifact(artifactName: string) {
 
 export async function postCommentIfInPr(message: string): Promise<string | undefined> {
   if (context.payload.pull_request) {
+    // Hashes followed by numbers are treated as references to a PR in GitHub, which
+    // changes how they are formatted. We do not want this.
+    // The regex below captures something like #12345 with whitespace either side
+    // (which is what GitHub would consider a PR), and adds &#8203; between the hash
+    // and the number. This is a zero-width space, which won't change what the message
+    // looks like but will ensure GitHub doesn't treat this as a PR.
+    const escapedMessage = message.replaceAll(/(\s)#([0-9]+\s)/g, '$1#&#8203;$2')
     const commentUrl = (
       await getOctokit(getInput('token')).rest.issues.createComment({
         ...context.repo,
         issue_number: context.payload.pull_request.number,
-        body: message,
+        body: escapedMessage,
       })
     ).data.html_url
     return commentUrl


### PR DESCRIPTION
Should fix comments like this one: https://github.com/lacework-dev/WebGoat/pull/9#issuecomment-1400317398