### PR TITLE
feat(RAIN-47438): Show code flows in PR comments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'fs'
 import { downloadArtifact, postCommentIfInPr, uploadArtifact } from './actions'
 import { compareSastResults, printSastResults } from './sast'
 import { compareScaResults, printScaResults } from './sca'
+import { Issue } from './types'
 import { callLaceworkCli } from './util'
 
 const scaReport = 'sca.json'
@@ -41,7 +42,7 @@ async function displayResults() {
   info('Displaying results')
   await downloadArtifact('results-old')
   await downloadArtifact('results-new')
-  const issuesByTool: { [tool: string]: string[] } = {}
+  const issuesByTool: { [tool: string]: Issue[] } = {}
   if (existsSync(`results-old/${scaReport}`) && existsSync(`results-new/${scaReport}`)) {
     issuesByTool['sca'] = await compareScaResults(
       `results-old/${scaReport}`,
@@ -61,7 +62,11 @@ async function displayResults() {
       if (issues.length > 0) {
         message += `\n\n<details><summary>${tool} found ${issues.length} potential new issues</summary>\n\n`
         for (const issue in issues) {
-          message += `* ${issues[issue]}\n`
+          message += `* ${issues[issue].summary}\n`
+          const details = issues[issue].details?.replaceAll('\n', '\n  ')
+          if (details !== undefined) {
+            message += `  <details><summary>More details</summary>\n  ${details}\n  </details>\n`
+          }
         }
         message += '\n</details>'
       }

--- a/src/sast.ts
+++ b/src/sast.ts
@@ -2,7 +2,8 @@ import { error, info, startGroup, endGroup } from '@actions/core'
 import { context } from '@actions/github'
 import { readFileSync } from 'fs'
 import { callLaceworkCli } from './util'
-import { Log } from 'sarif'
+import { Location, Log } from 'sarif'
+import { Issue } from './types'
 
 export async function printSastResults(sarifFile: string) {
   startGroup('Results for SAST')
@@ -23,7 +24,7 @@ export async function printSastResults(sarifFile: string) {
   endGroup()
 }
 
-export async function compareSastResults(oldReport: string, newReport: string) {
+export async function compareSastResults(oldReport: string, newReport: string): Promise<Issue[]> {
   startGroup('Comparing SAST results')
   info(
     await callLaceworkCli(
@@ -39,25 +40,36 @@ export async function compareSastResults(oldReport: string, newReport: string) {
   )
   const results: Log = JSON.parse(readFileSync('sast-compare.sarif', 'utf8'))
   let sawChange = false
-  const alertsAdded: string[] = []
+  const alertsAdded: Issue[] = []
   for (const run of results.runs) {
     if (Array.isArray(run.results) && run.results.length > 0) {
       info('There was changes in ' + run.results.length + ' results from ' + run.tool.driver.name)
       for (const vuln of run.results) {
         info(JSON.stringify(vuln, null, 2))
         if (vuln.properties?.['status'] === 'added') {
-          let location = 'Unknown location'
-          const uri = vuln.locations?.[0].physicalLocation?.artifactLocation?.uri
-          const line = vuln.locations?.[0].physicalLocation?.region?.startLine
-          if (uri !== undefined && line !== undefined) {
-            const file = uri.replace(/^file:\/*/, '')
-            const text = `${file.split('/').pop()}:${line}`
-            const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/${context.sha}/${file}#L${line}`
-            location = `[${text}](${url})`
-          }
           const message =
             vuln.message.markdown || vuln.message.text || 'No information available on alert'
-          alertsAdded.push(`${location}: ${message}`)
+          let details = undefined
+          if (
+            vuln.codeFlows !== undefined &&
+            vuln.codeFlows.length > 0 &&
+            vuln.codeFlows[0].threadFlows.length > 0
+          ) {
+            const chosenFlow = vuln.codeFlows[0].threadFlows[0]
+            details = 'Example problematic flow of data:\n\n'
+            for (const flowLoc of chosenFlow.locations) {
+              const location = flowLoc.location
+              details += `  * ${prettyPrintSarifLocation(location)}`
+              if (location?.message?.text !== undefined) {
+                details += `: ${location.message.text}`
+              }
+              details += '\n'
+            }
+          }
+          alertsAdded.push({
+            summary: `${prettyPrintSarifLocation(vuln.locations?.[0])}: ${message}`,
+            details,
+          })
         }
       }
       if (alertsAdded.length > 0) {
@@ -73,4 +85,16 @@ export async function compareSastResults(oldReport: string, newReport: string) {
   }
   endGroup()
   return alertsAdded
+}
+
+function prettyPrintSarifLocation(sarifLocation: Location | undefined) {
+  const uri = sarifLocation?.physicalLocation?.artifactLocation?.uri
+  const line = sarifLocation?.physicalLocation?.region?.startLine
+  if (uri !== undefined && line !== undefined) {
+    const file = uri.replace(/^file:\/*/, '')
+    const text = `${file.split('/').pop()}:${line}`
+    const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/${context.sha}/${file}#L${line}`
+    return `[${text}](${url})`
+  }
+  return 'Unknown location'
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export type Issue = {
+  summary: string
+  details?: string
+}


### PR DESCRIPTION
This starts reading the `codeFlows` property of the SARIF file from SAST in order to produce a better comment which includes this information, such as this one: https://github.com/lacework-dev/code-analysis-test-repo/pull/5#issuecomment-1398693198

We can bike-shed some more on potential alternatives likes having the SAST tool itself output this and somehow propagating this to the PR comment, but for now I think this is an improvement we should merge to at least get something being displayed.