### PR TITLE
remove setup node

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -17,10 +17,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
       - name: Move action
         run: |
           mkdir ../action


### PR DESCRIPTION
For some reasons `RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -` was failing yesterday, perhaps due to temporary unavailability of `https://deb.nodesource.com/setup_16.x`. Now all works again. We do not need to setup `node` in the workflow manually anymore.