### PR TITLE
run with debug flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
 import { compareSastResults, printSastResults } from './sast'
 import { compareScaResults, printScaResults } from './sca'
 import { Issue } from './types'
-import { callLaceworkCli } from './util'
+import { callLaceworkCli, debug } from './util'
 
 const scaReport = 'sca.json'
 const sastReport = 'sast.sarif'
@@ -25,23 +25,28 @@ async function runAnalysis() {
     if (indirectDeps.toLowerCase() === 'false') {
       args.push('--eval-direct-only')
     }
+    if (debug()) {
+      args.push('--debug')
+    }
     info(await callLaceworkCli(...args))
     await printScaResults(scaReport)
     toUpload.push(scaReport)
   }
   if (tools.includes('sast')) {
-    info(
-      await callLaceworkCli(
-        'sast',
-        'scan',
-        '--verbose',
-        '--save-results',
-        '--classes',
-        getInput('jar'),
-        '-o',
-        sastReport
-      )
-    )
+    var args = [
+      'sast',
+      'scan',
+      '--verbose',
+      '--save-results',
+      '--classes',
+      getInput('jar'),
+      '-o',
+      sastReport,
+    ]
+    if (debug()) {
+      args.push('--debug')
+    }
+    info(await callLaceworkCli(...args))
     await printSastResults(sastReport)
     toUpload.push(sastReport)
   }


### PR DESCRIPTION
if the input variable `debug` is set to `true`, or if the workflow is run in `debug` mode, `sca` and `sast` are run with the additional `--debug` flag

an example of run in debug mode is https://github.com/lacework/rainbow/actions/runs/4281940177/jobs/7455577563