### PR TITLE
Enable more logging in test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -32,6 +32,7 @@ jobs:
           tools: sca,sast
           classes: target
           sources: ${{ github.workspace }}
+          debug: true
       - name: Check run succeeded
         env:
           RUN_OUTPUT: ${{ steps.run-action.outputs.push-completed }}

--- a/src/sast.ts
+++ b/src/sast.ts
@@ -1,7 +1,7 @@
 import { error, info, startGroup, endGroup } from '@actions/core'
 import { context } from '@actions/github'
 import { readFileSync } from 'fs'
-import { callLaceworkCli } from './util'
+import { callLaceworkCli, debug } from './util'
 import { Location, Log } from 'sarif'
 import { Issue } from './types'
 
@@ -26,18 +26,21 @@ export async function printSastResults(sarifFile: string) {
 
 export async function compareSastResults(oldReport: string, newReport: string): Promise<Issue[]> {
   startGroup('Comparing SAST results')
-  info(
-    await callLaceworkCli(
-      'sast',
-      'compare',
-      '--old',
-      oldReport,
-      '--new',
-      newReport,
-      '-o',
-      'sast-compare.sarif'
-    )
-  )
+  const args = [
+    'sast',
+    'compare',
+    '--verbose',
+    '--old',
+    oldReport,
+    '--new',
+    newReport,
+    '-o',
+    'sast-compare.sarif',
+  ]
+  if (debug()) {
+    args.push('--debug')
+  }
+  info(await callLaceworkCli(...args))
   const results: Log = JSON.parse(readFileSync('sast-compare.sarif', 'utf8'))
   let sawChange = false
   const alertsAdded: Issue[] = []

--- a/src/sca.ts
+++ b/src/sca.ts
@@ -1,7 +1,7 @@
 import { error, info, startGroup, endGroup } from '@actions/core'
 import { readFileSync } from 'fs'
 import { Issue } from './types'
-import { callLaceworkCli } from './util'
+import { callLaceworkCli, debug } from './util'
 
 export async function printScaResults(jsonFile: string) {
   startGroup('Results for SCA')
@@ -19,18 +19,11 @@ export async function printScaResults(jsonFile: string) {
 
 export async function compareScaResults(oldReport: string, newReport: string): Promise<Issue[]> {
   startGroup('Comparing SCA results')
-  info(
-    await callLaceworkCli(
-      'sca',
-      'compare',
-      '--old',
-      oldReport,
-      '--new',
-      newReport,
-      '-o',
-      'sca-compare.json'
-    )
-  )
+  const args = ['sca', 'compare', '--old', oldReport, '--new', newReport, '-o', 'sca-compare.json']
+  if (debug()) {
+    args.push('--debug')
+  }
+  info(await callLaceworkCli(...args))
   const results = JSON.parse(readFileSync('sca-compare.json', 'utf8'))
   const alertsAdded: Issue[] = []
   if (Array.isArray(results.Vulnerabilities) && results.Vulnerabilities.length > 0) {


### PR DESCRIPTION
Makes sure:

- `--verbose` is always passed.
- `--debug` is passed if `debug` is set on the workflow, and sets it on the test one.