### PR TITLE
Cache installation of components to reduce API calls

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -50,11 +50,21 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - shell: bash
+    - id: init
+      shell: bash
       run: |
         SCA_VERSION=0.0.22
         SAST_VERSION=0.0.33
         curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
+        echo "cache-key=$(date +'%Y-%m-%d')-$SCA_VERSION-$SAST_VERSION" >> $GITHUB_OUTPUT
+    - id: cache
+      uses: actions/cache/restore@v3
+      with:
+        path: ~/.config/lacework/components
+        key: lacework-${{ steps.init.outputs.cache-key }}
+    - if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
         echo "::group::Installing Lacework CLI components"
         lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sca --version "${SCA_VERSION}"
         lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sast --version "${SAST_VERSION}"
@@ -63,6 +73,13 @@ runs:
         lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" version
         lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component list
         echo "::endgroup::"
+    - if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: ~/.config/lacework/components
+        key: lacework-${{ steps.init.outputs.cache-key }}
+    - shell: bash
+      run: |
         cp -r "${{ github.action_path }}" ../lacework-code-security
         cd ../lacework-code-security
         HUSKY=0 npm install


### PR DESCRIPTION
We're making a lot of API calls to install the components which is resulting in us hitting some rate limits. Let's store these in the [Actions cache](https://github.com/actions/cache) for the repository instead of fetching them on every run, which should drastically reduce the number of calls we're making as well as make things quicker since downloading from the repo cache should be faster than requesting a download from our API server and then downloading from an S3 bucket.

The downside of this is it circumvents checking the feature flag, so if we opt out a user then they'll still be able to continue running things. To avoid this being perpetually true, include the current day in the cache key so that once a day we do the download via the normal route. Of course also include the current SCA and SAST versions in the key, so new versions get rolled out immediately by triggering a download from our API/S3.