### PR TITLE
bump components version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,8 +53,8 @@ runs:
     - id: init
       shell: bash
       run: |
-        SCA_VERSION=0.0.28
-        SAST_VERSION=0.0.39
+        SCA_VERSION=0.0.30
+        SAST_VERSION=0.0.40
         curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
         echo "cache-key=$(date +'%Y-%m-%d')-$SCA_VERSION-$SAST_VERSION" >> $GITHUB_OUTPUT
         echo "sca-version=$SCA_VERSION" >> $GITHUB_OUTPUT

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,18 @@ async function runAnalysis() {
   const indirectDeps = getInput('eval-indirect-dependencies')
   const toUpload: string[] = []
   if (tools.includes('sca')) {
-    var args = ['sca', 'git', '.', '--save-results', '-o', scaReport, '--formats', 'sarif', '--deployment', 'ci']
+    var args = [
+      'sca',
+      'git',
+      '.',
+      '--save-results',
+      '-o',
+      scaReport,
+      '--formats',
+      'sarif',
+      '--deployment',
+      'ci',
+    ]
     if (indirectDeps.toLowerCase() === 'false') {
       args.push('--eval-direct-only')
     }
@@ -42,7 +53,7 @@ async function runAnalysis() {
       '-o',
       sastReport,
       '--deployment',
-      'ci'
+      'ci',
     ]
     if (debug()) {
       args.push('--debug')

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ async function runAnalysis() {
   const indirectDeps = getInput('eval-indirect-dependencies')
   const toUpload: string[] = []
   if (tools.includes('sca')) {
-    var args = ['sca', 'git', '.', '--save-results', '-o', scaReport, '--formats', 'sarif']
+    var args = ['sca', 'git', '.', '--save-results', '-o', scaReport, '--formats', 'sarif', '--deployment', 'ci']
     if (indirectDeps.toLowerCase() === 'false') {
       args.push('--eval-direct-only')
     }
@@ -41,6 +41,8 @@ async function runAnalysis() {
       getOrDefault('sources', '.'),
       '-o',
       sastReport,
+      '--deployment',
+      'ci'
     ]
     if (debug()) {
       args.push('--debug')

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -42,6 +42,8 @@ export async function compareResults(
     `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/${context.sha}/$FILENAME#L$LINENUMBER`,
     '--markdown-variant',
     'GitHub',
+    '--deployment',
+    'ci',
   ]
   if (debug()) args.push('--debug')
   info(await callLaceworkCli(...args))


### PR DESCRIPTION
Notably, sast and sca now support telemetry and the flag `--deployment`