### PR TITLE
print stderr at every run

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -12,7 +12,7 @@ export function debug() {
 
 export async function callCommand(command: string, ...args: string[]) {
   const child = spawnSync(command, args)
-  if (debug() && child.stderr.toString() !== '') {
+  if (child.stderr.toString() !== '') {
     info(`stderr from command:\n${child.stderr.toString()}`)
   }
   if (child.status) {


### PR DESCRIPTION
Print the content of stderr (e.g., all logs) even if debug is `false`

This helps understanding in scenario like https://github.com/lacework/code-security-action/actions/runs/5044906503/attempts/1 where, before this PR, we wouldn't have been able to see any logs