### PR TITLE
chore: Update expected test output

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -53,14 +53,15 @@ jobs:
       - name: Check results
         working-directory: artifact
         run: |
-          export SCA_RESULTS=`jq '.Vulnerabilities | length' sca.json`
+          export SCA_RESULTS=`jq '.runs | map (.results | length) | add' sca.sarif`
+          expectedScaResults=3
           echo "Got $SCA_RESULTS from SCA"
-          if [ "$SCA_RESULTS" == "0" ]; then
-            echo "::error::Expected to have some SCA results!"
+          if [ "$SCA_RESULTS" != "$expectedScaResults" ]; then
+            echo "::error::Expected to have $expectedScaResults SCA results!"
             exit 1
           fi
-          export SAST_RESULTS=`jq '.runs[0].results | length' sast.sarif`
-          expectedSastResults=1
+          export SAST_RESULTS=`jq '.runs | map (.results | length) | add' sast.sarif`
+          expectedSastResults=2
           echo "Got $SAST_RESULTS from SAST"
           if [ "$SAST_RESULTS" != "$expectedSastResults" ]; then
             echo "::error::Expected to have $expectedSastResults SAST results!"


### PR DESCRIPTION
A few changes here:

1. We use SARIF for SCA in the action, so query that instead of a missing JSON object.
2. We might have more than one run in the SARIF (in particular SAST does this), so update the `jq` incantation to account for this.
3. Update the expected number of results for both.