### PR TITLE
chore: Bump SCA to 0.0.46

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,7 +53,7 @@ runs:
     - id: init
       shell: bash
       run: |
-        SCA_VERSION=0.0.40
+        SCA_VERSION=0.0.46
         SAST_VERSION=0.0.45
         curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
         echo "cache-key=$(date +'%Y-%m-%d')-$SCA_VERSION-$SAST_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
In particular, this version should start populating committer information and CI job information for the UI to use.