### PR TITLE
chore: Bump SCA to 0.0.48

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,7 +53,7 @@ runs:
     - id: init
       shell: bash
       run: |
-        SCA_VERSION=0.0.47
+        SCA_VERSION=0.0.48
         SAST_VERSION=0.0.45
         curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
         echo "cache-key=$(date +'%Y-%m-%d')-$SCA_VERSION-$SAST_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This version supports offline bazel golang scanner, better telemetry and bug fixes.