### PR TITLE
chore: bump SAST to 0.0.46

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           target: push
           tools: sca,sast
-          classes: target
+          classpath: target/test-project-0.1.0.jar
           sources: ${{ github.workspace }}
           debug: true
       - name: Check run succeeded
@@ -61,7 +61,7 @@ jobs:
             exit 1
           fi
           export SAST_RESULTS=`jq '.runs | map (.results | length) | add' sast.sarif`
-          expectedSastResults=2
+          expectedSastResults=1
           echo "Got $SAST_RESULTS from SAST"
           if [ "$SAST_RESULTS" != "$expectedSastResults" ]; then
             echo "::error::Expected to have $expectedSastResults SAST results!"

--- a/action.yaml
+++ b/action.yaml
@@ -2,8 +2,12 @@ name: 'lacework-code-security'
 description: "Scan code with Lacework's Code Security offering"
 author: 'Lacework'
 inputs:
+  classpath:
+    description: 'Specify the Java classpath'
+    required: false
+    default: '.'
   classes:
-    description: 'Classes directory or JAR file to analyze'
+    description: 'Classes directory or JAR file to analyze (DEPRECATED)'
     required: false
     default: '.'
   sources:
@@ -54,7 +58,7 @@ runs:
       shell: bash
       run: |
         SCA_VERSION=0.0.50
-        SAST_VERSION=0.0.45
+        SAST_VERSION=0.0.46
         curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
         echo "cache-key=$(date +'%Y-%m-%d')-$SCA_VERSION-$SAST_VERSION" >> $GITHUB_OUTPUT
         echo "sca-version=$SCA_VERSION" >> $GITHUB_OUTPUT
@@ -91,6 +95,7 @@ runs:
     - id: run-analysis
       uses: './../lacework-code-security'
       with:
+        classpath: '${{ inputs.classpath }}'
         classes: '${{ inputs.classes }}'
         sources: '${{ inputs.sources }}'
         target: '${{ inputs.target }}'

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ async function runAnalysis() {
   const tools = (getInput('tools') || 'sca').toLowerCase().split(',')
   const indirectDeps = getInput('eval-indirect-dependencies')
   const toUpload: string[] = []
+  const classpath = getInput('classpath') || getOrDefault('classes', '.')
   if (tools.includes('sca')) {
     var args = [
       'sca',
@@ -47,8 +48,8 @@ async function runAnalysis() {
       'sast',
       'scan',
       '--save-results',
-      '--classes',
-      getOrDefault('classes', '.'),
+      '--classpath',
+      classpath,
       '--sources',
       getOrDefault('sources', '.'),
       '-o',


### PR DESCRIPTION
The `--classes` option SAST which was previously accepting a directory or a JAR file has now been replaced by a more generic `--classpath` option which is intended to be the standard Java classpath containing all the classes including the dependencies or self-contained JAR or WAR files with nested JAR dependencies.

The main goal is to make the SAST API more generic and able to work in the same way with Mariana Trench and Infer.

This changes the public API of the action code so we will need to create a different release tag to migrate the place where this code is used progressively.