### PR TITLE
chore: Automate upgrading of v1 tag

### DIFF
--- a/.github/workflows/update-tag.yml
+++ b/.github/workflows/update-tag.yml
@@ -14,6 +14,16 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.RELENG_GH_TOKEN }}
+      - name: Wait for tests to pass
+        run: |
+          sleep 60
+          export RUNS=`gh run list --branch main --event push --limit 100 --json "headSha,workflowName,url"`
+          export URLS=`echo $RUNS | jq -r '.[] | select(.headSha == env.GITHUB_SHA) | select(.workflowName != env.GITHUB_WORKFLOW) | .url'`
+          while IFS= read -r url; do
+            echo "Waiting for $url to finish"
+            export RUN_ID=`echo $url | sed -e 's/\/.*\///g'`
+            gh run watch --exit-status --interval 60 "$RUN_ID"
+          done <<< "$URLS"
       - name: Upgrade tag
         run: |
           git tag -f v1

--- a/.github/workflows/update-tag.yml
+++ b/.github/workflows/update-tag.yml
@@ -1,0 +1,20 @@
+name: Upgrade v1 tag
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.RELENG_GH_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.RELENG_GH_TOKEN }}
+      - name: Upgrade tag
+        run: |
+          git tag -f v1
+          git push -f origin v1


### PR DESCRIPTION
This will save us having to manually run this after a merge to `main` in order to get things actually released.