### PR TITLE
chore: Improve how we handle spawning commands

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ async function runAnalysis() {
     if (debug()) {
       args.push('--debug')
     }
-    info(await callLaceworkCli(...args))
+    await callLaceworkCli(...args)
     await printResults('sca', scaReport)
     toUpload.push(scaReport)
   }
@@ -68,7 +68,7 @@ async function runAnalysis() {
     if (debug()) {
       args.push('--debug')
     }
-    info(await callLaceworkCli(...args))
+    await callLaceworkCli(...args)
     await printResults('sast', sastReport)
     toUpload.push(sastReport)
   }

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -46,7 +46,7 @@ export async function compareResults(
     'ci',
   ]
   if (debug()) args.push('--debug')
-  info(await callLaceworkCli(...args))
+  await callLaceworkCli(...args)
   endGroup()
   return existsSync(`${tool}.md`) ? readFileSync(`${tool}.md`, 'utf8') : ''
 }


### PR DESCRIPTION
I believe part of the reason we're causing errors when we call a command that produces a lot of output is that we try to dump the whole output from the command in one go rather than streaming it so it can be bufferred out in a sensible manner. This PR addresses that, and should allow us to use `debug` mode in more scenarios.