### PR TITLE
feat: Log catastrohpic errors to our telemetry

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -56,9 +56,12 @@ runs:
   steps:
     - id: init
       shell: bash
+      env:
+        LACEWORK_ACTION_REF: '${{ github.action_ref }}'
       run: |
         echo "LACEWORK_START_TIME=$(date --rfc-3339=seconds)" >> $GITHUB_ENV
         echo "LACEWORK_CONTEXT_ID=$(echo $RANDOM | md5sum | head -c 32)" >> $GITHUB_ENV
+        echo "LACEWORK_ACTION_REF=$(echo $LACEWORK_ACTION_REF)" >> $GITHUB_ENV
         SCA_VERSION=0.0.50
         SAST_VERSION=0.0.46
         curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
@@ -93,12 +96,9 @@ runs:
         HUSKY=0 npm install
         npm run compile
         pip install yq
-        yq -yi 'del(.runs.steps) | del(.outputs) | .runs.using="node16" | .runs.main="dist/src/index.js"' action.yaml
+        yq -yi 'del(.runs.steps) | del(.outputs) | .runs.using="node16" | .runs.main="dist/src/index.js" | .runs.post="dist/src/post.js"' action.yaml
     - id: run-analysis
       uses: './../lacework-code-security'
-      env:
-        ACTION_REF: '${{ github.action_ref }}'
-        RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
       with:
         classpath: '${{ inputs.classpath }}'
         classes: '${{ inputs.classes }}'

--- a/src/post.ts
+++ b/src/post.ts
@@ -1,0 +1,23 @@
+import { info, warning } from '@actions/core'
+import {
+  getActionRef,
+  getMsSinceStart,
+  getOptionalEnvVariable,
+  getRequiredEnvVariable,
+  getRunUrl,
+  telemetryCollector,
+} from './util'
+
+if (getOptionalEnvVariable('LACEWORK_WROTE_TELEMETRY', 'false') !== 'true') {
+  info("Telemetry wasn't previous reported, reporting unknown failure now")
+  telemetryCollector.addField('version', getActionRef())
+  telemetryCollector.addField('url', getRunUrl())
+  telemetryCollector.addField('repository', getRequiredEnvVariable('GITHUB_REPOSITORY'))
+  telemetryCollector.addField('duration.total', getMsSinceStart())
+  telemetryCollector.addField('error', 'Unknown catastrophic error')
+  telemetryCollector.report().catch((err) => {
+    warning('Failed to report telemetry: ' + err.message)
+  })
+} else {
+  info('Telemetry has been reported')
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,6 +19,19 @@ export function debug() {
   return getBooleanInput('debug') || isDebug()
 }
 
+export function getActionRef(): string {
+  return getOptionalEnvVariable('LACEWORK_ACTION_REF', 'unknown')
+}
+
+export function getRunUrl(): string {
+  let result = getRequiredEnvVariable('GITHUB_SERVER_URL')
+  result += '/'
+  result += getRequiredEnvVariable('GITHUB_REPOSITORY')
+  result += '/actions/runs/'
+  result += getRequiredEnvVariable('GITHUB_RUN_ID')
+  return result
+}
+
 export async function callCommand(command: string, ...args: string[]) {
   info('Invoking ' + command + ' ' + args.join(' '))
   const child = spawn(command, args, { stdio: 'inherit' })


### PR DESCRIPTION
In certain scenarios, we've observed not reaching our telemetry code because we fail with an error so catastrohpic that the runner crashes. This PR adds a post-run step where we can at least observe these errors and send back _something_ to say they happened even though we'll have lost the full context so won't be able to send back details of what the error was.