### PR TITLE
feat: Only install the tools we're actually using

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -58,6 +58,7 @@ runs:
       shell: bash
       env:
         LACEWORK_ACTION_REF: '${{ github.action_ref }}'
+        TOOLS: '${{ inputs.tools }}'
       run: |
         echo "LACEWORK_START_TIME=$(date --rfc-3339=seconds)" >> $GITHUB_ENV
         echo "LACEWORK_CONTEXT_ID=$(echo $RANDOM | md5sum | head -c 32)" >> $GITHUB_ENV
@@ -65,9 +66,17 @@ runs:
         SCA_VERSION=0.0.53
         SAST_VERSION=0.0.47
         curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
-        echo "cache-key=$(date +'%Y-%m-%d')-$SCA_VERSION-$SAST_VERSION" >> $GITHUB_OUTPUT
-        echo "sca-version=$SCA_VERSION" >> $GITHUB_OUTPUT
-        echo "sast-version=$SAST_VERSION" >> $GITHUB_OUTPUT
+        KEY="$(date +'%Y-%m-%d')"
+        if [[ $TOOLS == *"sca"* ]]; then
+          KEY="$KEY-sca-$SCA_VERSION"
+          echo "sca-version=$SCA_VERSION" >> $GITHUB_OUTPUT
+        fi
+        if [[ $TOOLS == *"sast"* ]]; then
+          KEY="$KEY-sast-$SAST_VERSION"
+          echo "sast-version=$SAST_VERSION" >> $GITHUB_OUTPUT
+        fi
+        HASH="$(echo $KEY | md5sum | head -c 8)"
+        echo "cache-key=$HASH" >> $GITHUB_OUTPUT
     - id: cache
       uses: actions/cache/restore@v3
       with:
@@ -77,8 +86,12 @@ runs:
       shell: bash
       run: |
         echo "::group::Installing Lacework CLI components"
-        lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sca --version "${{ steps.init.outputs.sca-version }}"
-        lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sast --version "${{ steps.init.outputs.sast-version }}"
+        if [[ "${{ steps.init.outputs.sca-version }}" != "" ]]; then
+          lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sca --version "${{ steps.init.outputs.sca-version }}"
+        fi
+        if [[ "${{ steps.init.outputs.sast-version }}" != "" ]]; then
+          lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sast --version "${{ steps.init.outputs.sast-version }}"
+        fi
         echo "::endgroup::"
         echo "::group::Printing Lacework CLI information"
         lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" version


### PR DESCRIPTION
This should make workflows only using one of the tools a little bit quicker, and also avoids issues for customers who are only feature flagged for one tool.