### PR TITLE
fix: Don't report unknown failure on cancelled runs

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -130,6 +130,10 @@ export function getIssuesApi() {
   return makeOctokit().rest.issues
 }
 
+export function getActionsApi() {
+  return makeOctokit().rest.actions
+}
+
 export function getOrgsApi() {
   return makeOctokit().rest.orgs
 }


### PR DESCRIPTION
Currently, we report an `Unknown failure` is our Action started running but didn't finish and we failed to otherwise report telemetry. This was added to catch issues like OOMs which might result in us not getting a chance to report telemetry in the normal way. However, we should exclude casees where the run was actually deliberately cancelled by the user from this code path. This PR adds that.