### PR TITLE
chore: bump SAST to 0.0.50

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -64,7 +64,7 @@ runs:
         echo "LACEWORK_CONTEXT_ID=$(echo $RANDOM | md5sum | head -c 32)" >> $GITHUB_ENV
         echo "LACEWORK_ACTION_REF=$(echo $LACEWORK_ACTION_REF)" >> $GITHUB_ENV
         SCA_VERSION=0.0.55
-        SAST_VERSION=0.0.47
+        SAST_VERSION=0.0.50
         curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
         KEY="$(date +'%Y-%m-%d')"
         if [[ $TOOLS == *"sca"* ]]; then


### PR DESCRIPTION
The SAST release have been fixed now. This should be good to go.