### PR TITLE
test(COD-1317): run the tests on Linux and macOS

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,7 +13,13 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-12
+          - ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/action.yaml
+++ b/action.yaml
@@ -54,13 +54,20 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - if: runner.os == 'Linux'
+      shell: bash
+      run: echo "LACEWORK_START_TIME=$(date --rfc-3339=seconds)" >> $GITHUB_ENV
+    - if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        brew install coreutils
+        echo "LACEWORK_START_TIME=$(gdate --rfc-3339=seconds)" >> $GITHUB_ENV
     - id: init
       shell: bash
       env:
         LACEWORK_ACTION_REF: '${{ github.action_ref }}'
         TOOLS: '${{ inputs.tools }}'
       run: |
-        echo "LACEWORK_START_TIME=$(date --rfc-3339=seconds)" >> $GITHUB_ENV
         echo "LACEWORK_CONTEXT_ID=$(echo $RANDOM | md5sum | head -c 32)" >> $GITHUB_ENV
         echo "LACEWORK_ACTION_REF=$(echo $LACEWORK_ACTION_REF)" >> $GITHUB_ENV
         SCA_VERSION=0.0.55
@@ -108,8 +115,7 @@ runs:
         cd ../lacework-code-security
         HUSKY=0 npm install
         npm run compile
-        pip install yq
-        yq -yi 'del(.runs.steps) | del(.outputs) | .runs.using="node16" | .runs.main="dist/src/index.js" | .runs.post="dist/src/post.js"' action.yaml
+        yq -i -o yaml 'del(.runs.steps) | del(.outputs) | .runs.using="node16" | .runs.main="dist/src/index.js" | .runs.post="dist/src/post.js"' action.yaml
     - id: run-analysis
       uses: './../lacework-code-security'
       with:


### PR DESCRIPTION
Make the action compatible with macOS and enable the integration tests for both platforms. The main thing to fix was to install `coreutils` on macOS in order to get `gdate` and `md5sum` and rely on the version of `yq` from the system instead of the one from `pip` since `pip` is installing incompatible versions on Linux and macOS.