### PR TITLE
fix(COD-1498): Include OS and architecture in binary cache key

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -74,6 +74,7 @@ runs:
         SAST_VERSION=0.0.50
         curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
         KEY="$(date +'%Y-%m-%d')"
+        KEY="$KEY-$RUNNER_OS-$RUNNER_ARCH"
         if [[ $TOOLS == *"sca"* ]]; then
           KEY="$KEY-sca-$SCA_VERSION"
           echo "sca-version=$SCA_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
It turns out that when we cache the download of the SAST and SCA binaries, we fail to account for the fact that these binaries are different between OSes and architectures. So we may try to use a Mac binary on Linux or vice versa which of course won't work. Let's include the OS and architecture in the cache key.