### PR TITLE
chore: Revert version of SCA to v0.0.57

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -70,7 +70,7 @@ runs:
       run: |
         echo "LACEWORK_CONTEXT_ID=$(echo $RANDOM | md5sum | head -c 32)" >> $GITHUB_ENV
         echo "LACEWORK_ACTION_REF=$(echo $LACEWORK_ACTION_REF)" >> $GITHUB_ENV
-        SCA_VERSION=0.0.58
+        SCA_VERSION=0.0.57
         SAST_VERSION=0.0.50
         curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
         KEY="$(date +'%Y-%m-%d')"


### PR DESCRIPTION
Revert version of SCA to v0.0.57 due to an increase of run-time of sca