### PR TITLE
COD-1580: Problem with sarif output

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Check results
         working-directory: artifact
         run: |
-          export SCA_RESULTS=`jq '.runs | map (.results | length) | add' scaReport/output.sarif`
+          export SCA_RESULTS=`jq '.runs | map (.results | length) | add' sca.sarif`
           expectedScaResults=3
           echo "Got $SCA_RESULTS from SCA"
           if [ "$SCA_RESULTS" != "$expectedScaResults" ]; then

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { downloadKeys, trustedKeys } from './keys'
 
 const scaSarifReport = 'scaReport/output.sarif'
 const sastReport = 'sast.sarif'
+const scaReport = 'sca.sarif'
 const scaLWJSONReport = 'scaReport/output-lw.json'
 const scaDir = 'scaReport'
 
@@ -68,14 +69,14 @@ async function runAnalysis() {
     }
     await callLaceworkCli(...args)
     // make a copy of the sarif file
-    args = [scaSarifReport, 'sca.sarif']
+    args = [scaSarifReport, scaReport]
     await callCommand('cp', ...args)
 
-    await printResults('sca', scaSarifReport)
+    await printResults('sca', scaReport)
     if (autofix()) {
       await createPRs(scaLWJSONReport)
     }
-    toUpload.push(scaSarifReport)
+    toUpload.push(scaReport)
   }
   if (tools.includes('sast')) {
     var args = [
@@ -114,11 +115,11 @@ async function displayResults() {
     (Date.now() - downloadStart).toString()
   )
   const issuesByTool: { [tool: string]: string } = {}
-  if (existsSync(`results-old/${scaSarifReport}`) && existsSync(`results-new/${scaSarifReport}`)) {
+  if (existsSync(`results-old/${scaReport}`) && existsSync(`results-new/${scaReport}`)) {
     issuesByTool['sca'] = await compareResults(
       'sca',
-      `results-old/${scaSarifReport}`,
-      `results-new/${scaSarifReport}`
+      `results-old/${scaReport}`,
+      `results-new/${scaReport}`
     )
   }
   if (existsSync(`results-old/${sastReport}`) && existsSync(`results-new/${sastReport}`)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
 import { compareResults, createPRs, printResults } from './tool'
 import {
   autofix,
+  callCommand,
   callLaceworkCli,
   debug,
   getActionRef,
@@ -66,6 +67,10 @@ async function runAnalysis() {
       args.push('--fix-suggestions')
     }
     await callLaceworkCli(...args)
+    // make a copy of the sarif file 
+    args = [scaSarifReport, 'sca.sarif']
+    await callCommand('cp', ...args)
+
     await printResults('sca', scaSarifReport)
     if (autofix()) {
       await createPRs(scaLWJSONReport)

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ async function runAnalysis() {
       args.push('--fix-suggestions')
     }
     await callLaceworkCli(...args)
-    // make a copy of the sarif file 
+    // make a copy of the sarif file
     args = [scaSarifReport, 'sca.sarif']
     await callCommand('cp', ...args)
 


### PR DESCRIPTION
in a prev PR the output format changed to a folder containing the sarif and the lwjson format of the SBOM and that broke workflows relying on the output being just a sarif file.