### PR TITLE
chore: revert to last working release

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -77,7 +77,7 @@ runs:
         echo "LACEWORK_CONTEXT_ID=$(echo $LACEWORK_CONTEXT_ID)" >> $GITHUB_ENV
         echo "LACEWORK_ACTION_REF=$(echo $LACEWORK_ACTION_REF)" >> $GITHUB_ENV
         SCA_VERSION=0.0.64
-        SAST_VERSION=0.0.53
+        SAST_VERSION=0.0.52
         curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
         KEY="$(date +'%Y-%m-%d')"
         KEY="$KEY-$RUNNER_OS-$RUNNER_ARCH"


### PR DESCRIPTION
The latest release is failing because of [malformed SARIF file](https://github.com/lacework/rainbow/actions/runs/6070172340/job/16465742141#step:9:281). This PR reverts SAST to the previous release.