### PR TITLE
chore: Recommend Ubuntu 20.04 instead of 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ env:
 name: Lacework Code Security (PR)
 jobs:
   run-analysis:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     name: Run analysis
     strategy:
       matrix:
@@ -53,7 +53,7 @@ jobs:
           # or built JAR for your project
           # classes: target
   display-results:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     name: Display results
     needs:
       - run-analysis
@@ -83,7 +83,7 @@ env:
 name: Lacework Code Security (Push)
 jobs:
   run-analysis:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     name: Run analysis
     steps:
       - name: Checkout repository


### PR DESCRIPTION
With 22.04, we sometimes failed to report telemetry due to this known issue: https://github.com/actions/runner-images/issues/6709

Let's advise customers to use 20.04 instead - it should work just as well and is better for our observability.