### PR TITLE
fix: Make downloading of keys more robust

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -115,6 +115,9 @@ runs:
       with:
         path: ~/.config/lacework/components
         key: lacework-${{ steps.init.outputs.cache-key }}
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
     - shell: bash
       run: |
         cp -r "${{ github.action_path }}" ../lacework-code-security

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,13 +169,7 @@ async function main() {
 
 main()
   .catch((e) => {
-    if (typeof e === 'string') {
-      telemetryCollector.addField('error', e)
-    } else if (e instanceof Error) {
-      telemetryCollector.addField('error', e.message)
-    } else {
-      telemetryCollector.addField('error', 'Unknown error')
-    }
+    telemetryCollector.addError('error', e)
     error(e.message) // TODO: Use setFailed once we want failures to be fatal
   })
   .finally(async () => {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -9,6 +9,16 @@ export class TelemetryCollector {
     this.data[name] = value
   }
 
+  addError(name: string, e: any) {
+    if (typeof e === 'string') {
+      this.addField('error', e)
+    } else if (e instanceof Error) {
+      this.addField('error', e.message)
+    } else {
+      this.addField('error', 'Unknown error')
+    }
+  }
+
   async report() {
     let file = fileSync().name
     writeFileSync(file, JSON.stringify(this.data))


### PR DESCRIPTION
Follow-up from [this](https://github.com/aleftik/microservices-demo/actions/runs/6202190073/job/16840427733#step:3:424) failure being encountered.

Failures in this code shouldn't be fatal so let's just log a warning, report them in our telemetry and continue. Also, make sure to always set up the version of Node we need which may have been the cause of the problem observed (our action was being run on a self-hosted runner with an old version of Node).