### PR TITLE
fix(COD-1811): Fix no such file or directory error

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -120,6 +120,7 @@ runs:
         node-version: 16
     - shell: bash
       run: |
+        rm -rf ../lacework-code-security
         cp -r "${{ github.action_path }}" ../lacework-code-security
         cd ../lacework-code-security
         HUSKY=0 npm install

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -10,6 +10,7 @@ export const trustedKeys = 'laceworkTrustedKeys'
 export async function downloadKeys(): Promise<void> {
   const keyDownloadStart = Date.now()
   try {
+    mkdirSync(trustedKeys)
     const cacheKey = getCacheKey()
     const cacheResult = await restoreCache([trustedKeys], cacheKey)
     if (cacheResult !== undefined) {
@@ -17,14 +18,13 @@ export async function downloadKeys(): Promise<void> {
     }
     const users = await getOrgMembers()
     info(`Downloading trusted keys for ${users.length} users: ${users.join(', ')}`)
-    mkdirSync(trustedKeys)
     await Promise.all(users.map(downloadKeysForUser))
     await saveCache([trustedKeys], cacheKey)
     const downloaded = readdirSync(trustedKeys)
     info(`Successfully downloaded ${downloaded.length} trusted keys: ${downloaded.join(', ')}`)
   } catch (e) {
     telemetryCollector.addError('key-download-error', e)
-    warning(`Failed to download trusted keys: ${e}`)
+    info(`Failed to download trusted keys: ${e}`)
   } finally {
     telemetryCollector.addField('duration.key-download', (Date.now() - keyDownloadStart).toString())
   }


### PR DESCRIPTION
A few fixes:

1. Add `rm -rf ../lacework-code-security` to make sure we overwrite previous versions of the action that may still be present on self-hosted runners, ensuring we actually always run the latest code. (This was the reason the `catch` added in the previous PR wasn't working.)
2. Move `mkdirSync` to higher up, as apparently on self-hosted runners the code in `restoreCache` fails upon trying to create this.
3. Downgrade the `warning` if we fail to an `info` message, since this is expected to happen when the repo is a personal one rather than an org, so warning is a bit too noisy.

Sample run after these changes on the previously problematic repo: https://github.com/aleftik/microservices-demo/actions/runs/6246738738