### PR TITLE
feat(COD-1929): change the default value for the Java classpath

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,11 +5,7 @@ inputs:
   classpath:
     description: 'Specify the Java classpath'
     required: false
-    default: '.'
-  classes:
-    description: 'Classes directory or JAR file to analyze (DEPRECATED)'
-    required: false
-    default: '.'
+    default: ''
   sources:
     description: 'Sources directory to analyze'
     required: false
@@ -134,7 +130,6 @@ runs:
       uses: './../lacework-code-security'
       with:
         classpath: '${{ inputs.classpath }}'
-        classes: '${{ inputs.classes }}'
         sources: '${{ inputs.sources }}'
         target: '${{ inputs.target }}'
         debug: '${{ inputs.debug }}'

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,6 @@ async function runAnalysis() {
   appendFileSync(getRequiredEnvVariable('GITHUB_ENV'), `LACEWORK_TOOLS=${tools.join(',')}\n`)
   const indirectDeps = getInput('eval-indirect-dependencies')
   const toUpload: string[] = []
-  const classpath = getInput('classpath') || getOrDefault('classes', '.')
   if (tools.includes('sca')) {
     await downloadKeys()
     // command to print both sarif and lwjson formats
@@ -87,8 +86,6 @@ async function runAnalysis() {
       'sast',
       'scan',
       '--save-results',
-      '--classpath',
-      classpath,
       '--sources',
       getOrDefault('sources', '.'),
       '-o',
@@ -98,6 +95,11 @@ async function runAnalysis() {
     ]
     if (debug()) {
       args.push('--debug')
+    }
+    var classpath = getInput('classpath')
+    if (classpath) {
+      args.push('--classpath')
+      args.push(classpath)
     }
     await callLaceworkCli(...args)
     await printResults('sast', sastReport)


### PR DESCRIPTION
The SAST component now runs QuickSAST by default and relies on the value of the Java classpath to enable DeepSAST. This will allow the GitHub action code to run QuickSAST by default if the classpath is not specified. See https://github.com/lacework-dev/codesec/pull/187.