### PR TITLE
fix(COD-2376): Error retrieving branch in GitHub PRs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
   debug,
   getActionRef,
   getMsSinceStart,
+  getOptionalEnvVariable,
   getOrDefault,
   getRequiredEnvVariable,
   getRunUrl,
@@ -30,6 +31,17 @@ const scaDir = 'scaReport'
 
 async function runAnalysis() {
   const target = getInput('target')
+
+  let currBranch = getOptionalEnvVariable('GITHUB_HEAD_REF', '')
+  if (currBranch !== '') {
+    // running on a PR
+    if (target == 'old') {
+      process.env['LW_CODESEC_GIT_BRANCH'] = getOptionalEnvVariable('GITHUB_BASE_REF', '')
+    } else {
+      process.env['LW_CODESEC_GIT_BRANCH'] = currBranch
+    }
+  }
+
   info('Analyzing ' + target)
   const tools = (getInput('tools') || 'sca')
     .toLowerCase()


### PR DESCRIPTION
Detect if the GitHub action has been triggered in a PR and provide branch information to CodeSec tools.

Tested in https://github.com/lacework-dev/code-analysis-test-repo/actions/runs/7413026134/job/20171094879?pr=305#step:5:423  https://github.com/lacework-dev/code-analysis-test-repo/actions/runs/7413026134/job/20171094615?pr=305#step:5:422