### PR TITLE
Remove the Ariadne name from the Autofix output

### DIFF
--- a/src/tool.ts
+++ b/src/tool.ts
@@ -98,7 +98,7 @@ export async function prForFixSuggestion(
 
   // parse the modified files from the patch summary
   const startKeyword = '## Files that have been modified:'
-  const endKeyword = '## Explanation: why is this fix recommended by Ariadne?'
+  const endKeyword = '## Explanation: why is this SmartFix recommended?'
 
   const startIndex = patch.indexOf(startKeyword)
   const endIndex = patch.indexOf(endKeyword, startIndex)


### PR DESCRIPTION

This PR updates tool.ts to accomodate a change in the autofix output done in this other PR: https://github.com/lacework-dev/codesec/pull/433 