### PR TITLE
test(COD-2736): remove unused dotnet step

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Build sample repo
         run: |
           mvn --quiet package
-          dotnet publish --output target/
       - name: Run action
         id: run-action
         uses: ./../action
@@ -66,7 +65,7 @@ jobs:
         working-directory: artifact
         run: |
           export SCA_RESULTS=`jq '.runs | map (.results | length) | add' sca.sarif`
-          expectedScaResults=5
+          expectedScaResults=3
           echo "Got $SCA_RESULTS from SCA"
           if [ "$SCA_RESULTS" != "$expectedScaResults" ]; then
             echo "::error::Expected to have $expectedScaResults SCA results!"


### PR DESCRIPTION
Before this PR, the SCA integration tests was relying on running `dotnet publish` before running SCA. I don't know if this is the expected behavior. It may be preferable for the integration tests to be "buildless" since this is the user workflow we mostly intend to promote.

The actual differences we get after removing the `dotnet publish` build steps are here: https://gist.github.com/jeremydubreil/d37158848e508cc4851331771de137a3

