### PR TITLE
skip autofix on 'old' target

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -24,7 +24,9 @@ export function getActionRef(): string {
 }
 
 export function autofix() {
-  return getBooleanInput('autofix')
+  // autofix does fix all vulnerabilities, regardless of whether they are newly introduced or no
+  // for this reason, we skip if we are scanning the old branch
+  return getBooleanInput('autofix') && getInput('target') != 'old'
 }
 
 export function dynamic() {


### PR DESCRIPTION
Autofix does fix all the vulnerabilities, regardless of whether they are newly introduced, so we don't want to run sca on 'old' to avoid concurrency issues due to autofix generating the same branch multiple times