### PR TITLE
chore(COD-3829): delete the Lacework codesec config file

### DIFF
--- a/.lacework/codesec.yaml
+++ b/.lacework/codesec.yaml
@@ -1,4 +1,0 @@
-default:
-  sca:
-    enable-dynamic: true
-    enable-fast: true


### PR DESCRIPTION
These config file is not needed anymore.