### PR TITLE
feat(COD-4237): remove the SCA version check

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
 
 env:
   LW_ACCOUNT_NAME: ${{ secrets.LW_ACCOUNT_CAT }}

--- a/action.yaml
+++ b/action.yaml
@@ -59,42 +59,19 @@ runs:
         echo "Lacework context ID: $LACEWORK_CONTEXT_ID"
         echo "LACEWORK_CONTEXT_ID=$(echo $LACEWORK_CONTEXT_ID)" >> $GITHUB_ENV
         echo "LACEWORK_ACTION_REF=$(echo $LACEWORK_ACTION_REF)" >> $GITHUB_ENV
-        SCA_VERSION=0.1.23
         curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
-        KEY="$(date +'%Y-%m-%d')"
-        KEY="$KEY-$RUNNER_OS-$RUNNER_ARCH"
-        KEY="$KEY-sca-$SCA_VERSION"
-        echo "sca-version=$SCA_VERSION" >> $GITHUB_OUTPUT
-        HASH="$(echo $KEY | md5sum | head -c 8)"
-        echo "cache-key=$HASH" >> $GITHUB_OUTPUT
-    - id: cache
-      uses: actions/cache/restore@v3
-      with:
-        path: ~/.config/lacework/components
-        key: lacework-${{ steps.init.outputs.cache-key }}
     - name: Sets LW_LOG var for debug
       shell: bash
       if: ${{ inputs.debug == 'true' }}
       run: |
         echo "LW_LOG=debug" >> $GITHUB_ENV
-    - if: steps.cache.outputs.cache-hit != 'true'
+    - name: Install Lacework CLI component
       shell: bash
       run: |
-        echo "::group::Installing Lacework CLI components"
-        if [[ "${{ steps.init.outputs.sca-version }}" != "" ]]; then
-          lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sca --version "${{ steps.init.outputs.sca-version }}"
-        fi
-        echo "::endgroup::"
-        echo "::group::Printing Lacework CLI information"
+        lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" component install sca
         lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" version
-        echo "::endgroup::"
       env:
         CDK_DOWNLOAD_TIMEOUT_MINUTES: 2
-    - if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v3
-      with:
-        path: ~/.config/lacework/components
-        key: lacework-${{ steps.init.outputs.cache-key }}
     - uses: actions/setup-node@v3
       with:
         node-version: 16


### PR DESCRIPTION
This will let the Lacework CDK use the latest SCA release available for the associated account.

Tested in https://github.com/lacework-dev/WebGoat/pull/105#issuecomment-2545839593