### PR TITLE
chore(COD-4237): remove the hard-coded --secret option

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -80,7 +80,7 @@ runs:
       shell: bash
       if: ${{ inputs.debug == 'true' }}
       run: |
-          echo "LW_LOG=debug" >> $GITHUB_ENV
+        echo "LW_LOG=debug" >> $GITHUB_ENV
     - if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run: |

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
 import { error, getInput, info, setOutput, warning } from '@actions/core'
-import { existsSync, appendFileSync } from 'fs'
+import { appendFileSync, existsSync } from 'fs'
 import {
   downloadArtifact,
   postCommentIfInPr,
   resolveExistingCommentIfFound,
   uploadArtifact,
 } from './actions'
+import { downloadKeys, trustedKeys } from './keys'
 import { compareResults, createPRs, printResults } from './tool'
 import {
   autofix,
@@ -15,12 +16,10 @@ import {
   getActionRef,
   getMsSinceStart,
   getOptionalEnvVariable,
-  getOrDefault,
   getRequiredEnvVariable,
   getRunUrl,
   telemetryCollector,
 } from './util'
-import { downloadKeys, trustedKeys } from './keys'
 
 const scaSarifReport = 'scaReport/output.sarif'
 const scaReport = 'sca.sarif'
@@ -60,7 +59,6 @@ async function runAnalysis() {
     'ci',
     '--keyring',
     trustedKeys,
-    '--secret',
   ]
   if (indirectDeps.toLowerCase() === 'false') {
     args.push('--eval-direct-only')


### PR DESCRIPTION
There is no reason for the `--secret` to be hard-coded in the GitHub Actions code. This means the option can never be disabled since CLI options have the highest priority.