### PR TITLE
chore(COD-5174): use Node.js version 18

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -76,9 +76,9 @@ runs:
         lacework --noninteractive -a "${LW_ACCOUNT_NAME}" -k "${LW_API_KEY}" -s "${LW_API_SECRET}" version
       env:
         CDK_DOWNLOAD_TIMEOUT_MINUTES: 2
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: 18
     - shell: bash
       run: |
         rm -rf ../lacework-code-security


### PR DESCRIPTION
Address these [warning messages](https://github.com/lacework/services/actions/runs/15137572145/job/42552945155#step:4:119) raised because the version of Node.js is too old when scanning PRs.