### PR TITLE
chore(COD-6868): docker copy compare dir instead of one file at a time

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,7 @@
 import { error, getInput, info, isDebug } from '@actions/core'
 import { context } from '@actions/github'
 import { spawn } from 'child_process'
-import { readFileSync, mkdirSync, writeFileSync } from 'fs'
+import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 
@@ -246,51 +246,20 @@ export async function runCodesec(
     const compareDir = path.join(reportsDir, 'compare')
     mkdirSync(compareDir, { recursive: true })
 
-    // Copy all available comparison outputs
-    // merged-compare.md exists when both SCA and IAC comparisons succeed
-    // sca-compare.md / iac-compare.md exist for individual comparisons
-    let copiedAny = false
+    // Copy the entire compare directory out
+    await callCommand(
+      'docker',
+      'container',
+      'cp',
+      `${containerName}:/tmp/scan-results/compare/.`,
+      compareDir
+    )
 
-    try {
-      await callCommand(
-        'docker',
-        'container',
-        'cp',
-        `${containerName}:/tmp/scan-results/compare/merged-compare.md`,
-        path.join(compareDir, 'merged-compare.md')
-      )
-      copiedAny = true
-    } catch {
-      info('Merged compare output not found (partial compare mode)')
-    }
+    // Verify at least one output was produced
+    const compareFiles = ['merged-compare.md', 'sca-compare.md', 'iac-compare.md']
+    const copied = compareFiles.filter((f) => existsSync(path.join(compareDir, f)))
 
-    try {
-      await callCommand(
-        'docker',
-        'container',
-        'cp',
-        `${containerName}:/tmp/scan-results/compare/sca-compare.md`,
-        path.join(compareDir, 'sca-compare.md')
-      )
-      copiedAny = true
-    } catch {
-      info('SCA compare output not found (may have been skipped)')
-    }
-
-    try {
-      await callCommand(
-        'docker',
-        'container',
-        'cp',
-        `${containerName}:/tmp/scan-results/compare/iac-compare.md`,
-        path.join(compareDir, 'iac-compare.md')
-      )
-      copiedAny = true
-    } catch {
-      info('IAC compare output not found (may have been skipped)')
-    }
-
-    if (!copiedAny) {
+    if (copied.length === 0) {
       throw new Error('No comparison outputs found in container')
     }
 


### PR DESCRIPTION
## Linked JIRA issue(s)
https://lacework.atlassian.net/browse/COD-6868

## Description
Fix noisy `Error: Command failed with status 1` logs during compare mode when only a subset of
scanners is enabled (e.g. SCA only).

- Replaced 3 individual `docker cp` calls (each wrapped in try/catch) with a single `docker cp`
of the entire `compare/` directory, then verify locally which files were produced
- Previously, expected missing files (e.g. `iac-compare.md` when IAC is disabled) triggered
`callCommand`'s `error()` logging before the catch block could handle it gracefully
- No behavioral change — same files are copied, same validation that at least one output exists

## Tests and additional notes
https://github.com/lacework-dev/WebGoat/actions/runs/24084748514?pr=173