### PR TITLE
fix: bump to Node 24 to clear Node 20 deprecation warnings

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "17"

--- a/action.yaml
+++ b/action.yaml
@@ -68,9 +68,9 @@ runs:
         if [ -n "$LW_ACCOUNT_NAME" ]; then
           echo "LW_ACCOUNT=$LW_ACCOUNT_NAME" >> $GITHUB_ENV
         fi
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
-        node-version: 18
+        node-version: 24
     - shell: bash
       run: |
         rm -rf ../lacework-code-security
@@ -78,7 +78,7 @@ runs:
         cd ../lacework-code-security
         HUSKY=0 npm install
         npm run compile
-        yq -i -o yaml 'del(.runs.steps) | del(.outputs) | .runs.using="node16" | .runs.main="dist/src/index.js"' action.yaml
+        yq -i -o yaml 'del(.runs.steps) | del(.outputs) | .runs.using="node24" | .runs.main="dist/src/index.js"' action.yaml
     - id: run-analysis
       uses: './../lacework-code-security'
       with:


### PR DESCRIPTION
## Summary

Both runner-Node sources in this composite action emit GitHub's [Node 20 deprecation warning](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) (forced to Node 24 by default starting June 2, 2026; Node 20 removed from runners on Sep 16, 2026):

- \`actions/setup-node@v4\` — v4 runs on node20
- The runtime-rewritten \`./../lacework-code-security\` local action with \`runs.using=\"node16\"\` — runners silently upgrade node16 to node20

This PR bumps both to Node 24:
- \`actions/setup-node@v4\` → \`@v6\` (v6 uses node24)
- yq mutation: \`runs.using=\"node16\"\` → \`runs.using=\"node24\"\`
- \`node-version: 18\` → \`24\` to match the runtime that ends up executing the compiled JS

## Test plan

- [ ] Existing integration-test workflow on this branch should run on Node 24 and pass — the produced \`dist/src/index.js\` (\`@actions/*\`, \`@octokit/*\`, \`simple-git\`, \`tmp\`) is all node24-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)