### PR TITLE
chore(COD-7026): remove the unused artifact-prefix input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -19,10 +19,6 @@ inputs:
   footer:
     description: 'A block of Markdown that will be appended to any PR comments posted'
     required: false
-  artifact-prefix:
-    description: 'Prefix for the artifact name'
-    required: false
-    default: ''
   code-scanning-path:
     description: 'Path to write code scanning SARIF file'
     required: false
@@ -87,5 +83,4 @@ runs:
         debug: '${{ inputs.debug }}'
         token: '${{ inputs.token || github.token }}'
         footer: '${{ inputs.footer }}'
-        artifact-prefix: '${{ inputs.artifact-prefix }}'
         code-scanning-path: '${{ inputs.code-scanning-path }}'

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,9 +103,7 @@ async function runAnalysis() {
     }
   }
 
-  const artifactPrefix = getInput('artifact-prefix')
-  const artifactName =
-    artifactPrefix !== '' ? artifactPrefix + '-results-' + target : 'results-' + target
+  const artifactName = 'results-' + target
   info(`Uploading artifact '${artifactName}' with ${toUpload.length} file(s)`)
   await uploadArtifact(artifactName, ...toUpload)
   setOutput(`${target}-completed`, true)


### PR DESCRIPTION
This option was only used to allow the integration tests to pass on macOS and we no longer need this.

Tested here: https://github.com/lacework-dev/WebGoat/pull/180#issuecomment-4518353048