### PR TITLE
feat(COD-7079): skip the IaC scan when no IaC-related files are modified

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,12 +14,13 @@ import {
   getModifiedFiles,
   getOptionalEnvVariable,
   readMarkdownFile,
+  shouldRunIaCScanner,
 } from './util'
 import { simpleGit } from 'simple-git'
 
 // Global scanner toggles - set to false to disable a scanner globally
 const enableScaRunning = true
-const enableIacRunning = true
+let enableIacRunning = false
 
 async function runAnalysis() {
   const target = getInput('target')
@@ -50,6 +51,13 @@ async function runAnalysis() {
     modifiedFiles = getModifiedFiles()
     if (modifiedFiles) {
       info(`Modified files for optimised scanning: ${modifiedFiles}`)
+    }
+  }
+
+  // Skip the IaC scan if there no IaC-related files have been modified in the PR
+  if (modifiedFiles && target == 'new') {
+    if (shouldRunIaCScanner(modifiedFiles)) {
+      enableIacRunning = true
     }
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -140,6 +140,36 @@ export function getModifiedFiles(): string | undefined {
   return files || undefined
 }
 
+export function shouldRunIaCScanner(modifiedFiles: string): boolean {
+  const iacFileExtensions = ['.tf', '.hcl', '.yaml', '.yml', '.json']
+  const nonIaCFilenames = [
+    'package.json',
+    'package-lock.json',
+    'tsconfig.json',
+    'tsconfig.build.json',
+    'tslint.json',
+    'jest.config.json',
+    '.eslintrc.json',
+    '.prettierrc.json',
+    '.prettierrc.yaml',
+    '.prettierrc.yml',
+    'renovate.json',
+    'lerna.json',
+    'bower.json',
+    'composer.json',
+    'composer.lock',
+    'Pipfile.lock',
+    'cargo.lock',
+  ]
+  return modifiedFiles.split(',').some((file) => {
+    const filename = file.split('/').pop() || ''
+    if (nonIaCFilenames.includes(filename.toLowerCase())) {
+      return false
+    }
+    return iacFileExtensions.some((ext) => file.endsWith(ext))
+  })
+}
+
 // runCodesec - Docker-based scanner using codesec:latest image
 //
 // Modes:


### PR DESCRIPTION
Only run the IaC scanner when the PR are touching IaC files.

Tested [here](https://github.com/lacework-dev/WebGoat/actions/runs/26814675242/job/79053311860?pr=180#step:6:180) with a PR touching IaC files and [here](https://github.com/lacework-dev/WebGoat/actions/runs/26815784765/job/79057080281?pr=142#step:6:186) with a PR without IaC files.