### PR TITLE
fix(COD-6990): get the modified files compared to HEAD^1

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ async function runAnalysis() {
   // Only pass modified files for PR "new" scans — this optimises scanning to only changed files
   let modifiedFiles: string | undefined
   if (currBranch !== '' && target === 'new') {
-    modifiedFiles = getModifiedFiles()
+    modifiedFiles = await getModifiedFiles()
     if (modifiedFiles) {
       info(`Modified files for optimised scanning: ${modifiedFiles}`)
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,9 +1,10 @@
 import { error, getInput, info, isDebug } from '@actions/core'
 import { context } from '@actions/github'
-import { spawn, spawnSync } from 'child_process'
+import { spawn } from 'child_process'
 import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'fs'
 import * as os from 'os'
 import * as path from 'path'
+import { simpleGit } from 'simple-git'
 
 // Gather GITHUB_* and CI env vars for the lacework iac binary to read directly
 function gatherGitHubEnvVars(): string[] {
@@ -115,29 +116,15 @@ export function generateUILink() {
   return url
 }
 
-export function getModifiedFiles(): string | undefined {
-  const eventPath = process.env.GITHUB_EVENT_PATH
-  if (!eventPath) return undefined
-
-  let eventData: any
+export async function getModifiedFiles(): Promise<string | undefined> {
   try {
-    eventData = JSON.parse(readFileSync(eventPath, 'utf8'))
+    const diff = await simpleGit().diff(['--name-only', 'HEAD^1...HEAD'])
+    const files = diff.trim().split('\n').filter(Boolean).join(',')
+    return files || undefined
   } catch (e) {
-    info(`Failed to parse GitHub event file: ${e}`)
+    info(`Failed to get modified files: ${e}`)
     return undefined
   }
-
-  const baseSha = eventData.pull_request?.base?.sha
-  if (!baseSha) return undefined
-
-  const result = spawnSync('git', ['diff', '--name-only', `${baseSha}...HEAD`])
-  if (result.status !== 0) {
-    info(`Failed to get modified files: ${result.stderr?.toString()}`)
-    return undefined
-  }
-
-  const files = result.stdout.toString().trim().split('\n').filter(Boolean).join(',')
-  return files || undefined
 }
 
 export function shouldRunIaCScanner(modifiedFiles: string): boolean {


### PR DESCRIPTION
This changes the logic to get the list of modified files.

Before the changes, comparing `HEAD` with `${baseSha}` will sometimes fail because `${baseSha}` is not always available on a shallow clone (with depth 2). This will sometimes lead to failures like this one [here](https://github.com/lacework/services/actions/runs/26881672543/job/79283033264#step:4:137).

With this pull request, the code is now getting the list of modified files by comparing `HEAD` and `HEAD^1` which will always be available because of the workflow is doing a checkout with depth 2.

Tested here: https://github.com/lacework-dev/WebGoat/actions/runs/26878535025?pr=142