### PR TITLE
chore(COD-7117): add IaC prescan optimisation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ import {
   getModifiedFiles,
   getOptionalEnvVariable,
   readMarkdownFile,
-  shouldRunIaCScanner,
   generateCacheKey,
 } from './util'
 
@@ -53,13 +52,7 @@ async function runAnalysis() {
     }
   }
 
-  // Skip the IaC scan if there no IaC-related files have been modified in the PR
-  let enableIacRunning = true
-  if (modifiedFiles && target == 'new') {
-    if (!shouldRunIaCScanner(modifiedFiles)) {
-      enableIacRunning = false
-    }
-  }
+  const enableIacRunning = true
 
   // Create scan-results directory
   const resultsPath = path.join(process.cwd(), 'scan-results')

--- a/src/util.ts
+++ b/src/util.ts
@@ -127,7 +127,6 @@ export async function getModifiedFiles(): Promise<string | undefined> {
   }
 }
 
-
 // runCodesec - Docker-based scanner using codesec:latest image
 //
 // Modes:

--- a/src/util.ts
+++ b/src/util.ts
@@ -69,16 +69,11 @@ export async function callCommand(command: string, ...args: string[]) {
 }
 
 export async function tryCallCommand(command: string, ...args: string[]): Promise<boolean> {
-  info('Invoking ' + command + ' ' + args.join(' '))
-  const child = spawn(command, args, { stdio: 'inherit' })
+  const child = spawn(command, args, { stdio: 'ignore' })
   const exitCode = await new Promise((resolve, _) => {
     child.on('close', resolve)
   })
-  if (exitCode !== 0) {
-    info(`Command exited with status ${exitCode}`)
-    return false
-  }
-  return true
+  return exitCode === 0
 }
 
 export function getRequiredEnvVariable(name: string) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -127,35 +127,6 @@ export async function getModifiedFiles(): Promise<string | undefined> {
   }
 }
 
-export function shouldRunIaCScanner(modifiedFiles: string): boolean {
-  const iacFileExtensions = ['.tf', '.hcl', '.yaml', '.yml', '.json']
-  const nonIaCFilenames = [
-    'package.json',
-    'package-lock.json',
-    'tsconfig.json',
-    'tsconfig.build.json',
-    'tslint.json',
-    'jest.config.json',
-    '.eslintrc.json',
-    '.prettierrc.json',
-    '.prettierrc.yaml',
-    '.prettierrc.yml',
-    'renovate.json',
-    'lerna.json',
-    'bower.json',
-    'composer.json',
-    'composer.lock',
-    'Pipfile.lock',
-    'cargo.lock',
-  ]
-  return modifiedFiles.split(',').some((file) => {
-    const filename = file.split('/').pop() || ''
-    if (nonIaCFilenames.includes(filename.toLowerCase())) {
-      return false
-    }
-    return iacFileExtensions.some((ext) => file.endsWith(ext))
-  })
-}
 
 // runCodesec - Docker-based scanner using codesec:latest image
 //

--- a/src/util.ts
+++ b/src/util.ts
@@ -198,7 +198,7 @@ export async function runCodesec(
       `SCAN_TARGET=${scanTarget || 'scan'}`,
       ...(modifiedFiles ? ['-e', `MODIFIED_FILES=${modifiedFiles}`] : []),
       ...(computeCacheKey ? ['-e', 'GENERATE_CACHE_KEY=true'] : []),
-      'lacework/codesec:test',
+      'lacework/codesec:latest',
       'scan',
     ]
 
@@ -288,7 +288,7 @@ export async function runCodesec(
       `RUN_SCA=${runSca}`,
       '-e',
       `RUN_IAC=${runIac}`,
-      'lacework/codesec:test',
+      'lacework/codesec:latest',
       'compare',
     ]
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -68,6 +68,19 @@ export async function callCommand(command: string, ...args: string[]) {
   }
 }
 
+export async function tryCallCommand(command: string, ...args: string[]): Promise<boolean> {
+  info('Invoking ' + command + ' ' + args.join(' '))
+  const child = spawn(command, args, { stdio: 'inherit' })
+  const exitCode = await new Promise((resolve, _) => {
+    child.on('close', resolve)
+  })
+  if (exitCode !== 0) {
+    info(`Command exited with status ${exitCode}`)
+    return false
+  }
+  return true
+}
+
 export function getRequiredEnvVariable(name: string) {
   const value = process.env[name]
   if (!value) {
@@ -231,13 +244,16 @@ export async function runCodesec(
     if (runIac) {
       const iacDir = path.join(reportsDir, 'iac')
       mkdirSync(iacDir, { recursive: true })
-      await callCommand(
+      const copied = await tryCallCommand(
         'docker',
         'container',
         'cp',
         `${containerName}:/tmp/scan-results/iac/iac-${scanTarget || 'scan'}.json`,
         path.join(iacDir, `iac-${scanTarget || 'scan'}.json`)
       )
+      if (!copied) {
+        info('IaC results not produced — scanner likely skipped IaC')
+      }
     }
 
     // Cleanup container

--- a/src/util.ts
+++ b/src/util.ts
@@ -220,7 +220,7 @@ export async function runCodesec(
       `SCAN_TARGET=${scanTarget || 'scan'}`,
       ...(modifiedFiles ? ['-e', `MODIFIED_FILES=${modifiedFiles}`] : []),
       ...(computeCacheKey ? ['-e', 'GENERATE_CACHE_KEY=true'] : []),
-      'lacework/codesec:latest',
+      'lacework/codesec:test',
       'scan',
     ]
 
@@ -307,7 +307,7 @@ export async function runCodesec(
       `RUN_SCA=${runSca}`,
       '-e',
       `RUN_IAC=${runIac}`,
-      'lacework/codesec:latest',
+      'lacework/codesec:test',
       'compare',
     ]
 


### PR DESCRIPTION
## Linked JIRA issue(s)

  https://lacework.atlassian.net/browse/COD-7117

  ## Description

  Delegate IaC scan skip decision to the Docker image instead.

  - Remove `shouldRunIaCScanner` — the Docker image's `lacework iac pre-scan` now owns whether to run IaC
  - Set `enableIacRunning = true` unconditionally so IaC is always requested; the container skips internally when no relevant files are modified
  - Add `tryCallCommand` to tolerate missing IaC result files (no error annotation when the container legitimately skips IaC)

Run with terraform file: https://github.com/lacework-dev/WebGoat/actions/runs/27279156904/job/80582118938
Run with no IaC files: https://github.com/lacework-dev/WebGoat/actions/runs/27283130346/job/80582859977?pr=172
Run with bait IaC files (random.json): https://github.com/lacework-dev/WebGoat/actions/runs/27284639958/job/80588343384?pr=172 -- triggers iac prescan but does not do full scan