### PR TITLE
fix(LINK-4383): mount checkout at host path so container git can authenticate

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -131,6 +131,44 @@ export async function getModifiedFiles(): Promise<string | undefined> {
   }
 }
 
+// gitWorkspaceDockerArgs - mount the checkout and expose GitHub credentials to
+// git inside the container.
+//
+// The scanner runs `git remote show origin` to determine the repository's
+// default branch, which needs working GitHub credentials. actions/checkout wires
+// these by writing an `http.<host>.extraheader` AUTHORIZATION entry into a config
+// file under RUNNER_TEMP and referencing it from the repo's .git/config with an
+// `includeIf.gitdir:<host checkout path>/.git` entry. To make that resolve inside
+// the container we:
+//   - mount the checkout at its original host path so the gitdir condition matches
+//   - mount RUNNER_TEMP so the referenced credentials file is reachable
+//   - point WORKSPACE at the host path and mark it a safe directory (the image's
+//     built-in `/app/${WORKSPACE}` safe.directory no longer applies)
+function gitWorkspaceDockerArgs(): string[] {
+  const workspace = process.cwd()
+  const args = ['-v', `${workspace}:${workspace}`]
+
+  const runnerTemp = process.env.RUNNER_TEMP
+  if (runnerTemp && existsSync(runnerTemp)) {
+    args.push('-v', `${runnerTemp}:${runnerTemp}`)
+  } else {
+    info('RUNNER_TEMP not set — git credentials may be unavailable inside the container')
+  }
+
+  args.push(
+    '-e',
+    `WORKSPACE=${workspace}`,
+    '-e',
+    'GIT_CONFIG_COUNT=1',
+    '-e',
+    'GIT_CONFIG_KEY_0=safe.directory',
+    '-e',
+    `GIT_CONFIG_VALUE_0=${workspace}`
+  )
+
+  return args
+}
+
 // runCodesecScan - Docker-based scanner using codesec:latest image
 //
 // Parameters:
@@ -163,12 +201,9 @@ export async function runCodesecScan(
     'run',
     '--name',
     containerName,
-    '-v',
-    `${process.cwd()}:/app/src`,
+    ...gitWorkspaceDockerArgs(),
     '--env-file',
     envFile,
-    '-e',
-    `WORKSPACE=src`,
     '-e',
     `LW_ACCOUNT=${lwAccount}`,
     '-e',
@@ -254,14 +289,11 @@ export async function runCodesecCompare(): Promise<string | null> {
     'run',
     '--name',
     containerName,
-    '-v',
-    `${process.cwd()}:/app/src`,
+    ...gitWorkspaceDockerArgs(),
     '-v',
     `${path.join(process.cwd(), 'scan-results')}:/app/scan-results`,
     '--env-file',
     envFile,
-    '-e',
-    `WORKSPACE=src`,
     '-e',
     `LW_ACCOUNT=${lwAccount}`,
     '-e',


### PR DESCRIPTION
This PR adds code to pass more information to the `docker run` command to make sure that the `git` invocations happening during the `sca scan` are working as expected.

Tested that the new code on **WebGoat** which was previously working to make sure there is no regressions: PR comment created here: https://github.com/lacework-dev/WebGoat/pull/180#issuecomment-4781331905

Test on **services** that was not fully working before because the default branch could not be correctly retrieved before: https://github.com/lacework/code-security-action/pull/273#issue-4726294861

Before these changes, we were getting the following error on **services**: https://github.com/lacework/services/actions/runs/28084648774/job/83147543749#step:3:172